### PR TITLE
Fix: ai image generation error

### DIFF
--- a/src/landppt/services/ppt_image_processor.py
+++ b/src/landppt/services/ppt_image_processor.py
@@ -659,7 +659,11 @@ class PPTImageProcessor:
                     provider = ImageProvider.STABLE_DIFFUSION
                 elif default_provider == 'pollinations':
                     provider = ImageProvider.POLLINATIONS
-
+                elif default_provider == 'gemini':
+                    provder = ImageProvider.GEMINI
+                elif default_provider == 'openai_image':
+                    provider = ImageProvider.OPENAI_IMAGE
+    
                 generation_request = ImageGenerationRequest(
                     prompt=image_prompt,
                     provider=provider,


### PR DESCRIPTION
### fix:
- 解析图片提供商时遗漏了 gemini 和 openai_image
- 在提取 json 时，是通过检测 `{}` 对来实现。当 content 中包含 think 内容时，由于 json 内容在 think 和正式回复中各出现了一次，导致 json.loads 的参数变成类似：
```
{"need_image": True, ... </think> \n\n {"need_image": ... }
```
从而导致 json 提取出错