### PR TITLE
feat: upgrade MiniMax from M2.1 to M2.7 and fix API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,9 +46,11 @@ KIMI_BASE_URL=https://api.moonshot.cn/v1
 KIMI_MODEL=kimi-k2.5
 
 # MiniMax
+# Get your API key from: https://platform.minimaxi.com/
+# Available models: MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
 MINIMAX_API_KEY=
-MINIMAX_BASE_URL=https://api.minimaxi.com/v1
-MINIMAX_MODEL=MiniMax-M2.1
+MINIMAX_BASE_URL=https://api.minimax.io/v1
+MINIMAX_MODEL=MiniMax-M2.7
 
 # Anthropic Configuration
 # Get your API key from: https://console.anthropic.com/

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ LandPPT 是一个基于大语言模型（LLM）的智能演示文稿生成平台
 
 ###  多AI提供商支持
 - **OpenAI GPT系列**：GPT-4o、GPT-4o-mini 等模型，支持官方 Responses API 与 reasoning effort 推理程度参数
-- **OpenAI兼容提供商**：DeepSeek、Kimi、MiniMax 等（通过 Base URL + API Key 接入）
+- **OpenAI兼容提供商**：DeepSeek、Kimi、MiniMax（M2.7 / M2.5）等（通过 Base URL + API Key 接入）
 - **Anthropic Claude**：Claude-4 Sonnet、Claude-4 Haiku 系列模型
 - **Google Gemini**：Gemini-2.5 Flash、Gemini-2.5 Pro 系列模型，支持自定义端点配置
 - **Ollama**：本地部署的开源模型，支持 Llama、Mistral 等
@@ -297,8 +297,8 @@ KIMI_BASE_URL=https://api.moonshot.cn/v1
 KIMI_MODEL=kimi-k2.5
 
 MINIMAX_API_KEY=
-MINIMAX_BASE_URL=https://api.minimaxi.com/v1
-MINIMAX_MODEL=MiniMax-M2.1
+MINIMAX_BASE_URL=https://api.minimax.io/v1
+MINIMAX_MODEL=MiniMax-M2.7
 
 # 302.AI（OpenAI兼容）
 302AI_API_KEY=

--- a/README_EN.md
+++ b/README_EN.md
@@ -93,7 +93,7 @@ LandPPT is an intelligent presentation generation platform powered by Large Lang
 
 ###  Multi-AI Provider Support
 - **OpenAI**: GPT-4o, GPT-4o-mini and other latest models, with support for the official Responses API and reasoning effort parameters
-- **OpenAI-Compatible**: DeepSeek / Kimi / MiniMax / 302.AI (via Base URL + API Key)
+- **OpenAI-Compatible**: DeepSeek / Kimi / MiniMax (M2.7 / M2.5) / 302.AI (via Base URL + API Key)
 - **Anthropic Claude**: Claude-4 series models
 - **Google Gemini**: Gemini-2.5 series models with custom endpoint support
 - **Ollama**: Locally deployed open-source models supporting Llama, Mistral, etc.
@@ -289,8 +289,8 @@ KIMI_BASE_URL=https://api.moonshot.cn/v1
 KIMI_MODEL=kimi-k2.5
 
 MINIMAX_API_KEY=
-MINIMAX_BASE_URL=https://api.minimaxi.com/v1
-MINIMAX_MODEL=MiniMax-M2.1
+MINIMAX_BASE_URL=https://api.minimax.io/v1
+MINIMAX_MODEL=MiniMax-M2.7
 
 # 302.AI (OpenAI-Compatible)
 302AI_API_KEY=

--- a/src/landppt/core/config.py
+++ b/src/landppt/core/config.py
@@ -51,8 +51,8 @@ class AIConfig(BaseSettings):
     kimi_model: str = Field(default="kimi-k2.5", env="KIMI_MODEL")
 
     minimax_api_key: Optional[str] = Field(default=None, env="MINIMAX_API_KEY")
-    minimax_base_url: str = Field(default="https://api.minimaxi.com/v1", env="MINIMAX_BASE_URL")
-    minimax_model: str = Field(default="MiniMax-M2.1", env="MINIMAX_MODEL")
+    minimax_base_url: str = Field(default="https://api.minimax.io/v1", env="MINIMAX_BASE_URL")
+    minimax_model: str = Field(default="MiniMax-M2.7", env="MINIMAX_MODEL")
     
     # Anthropic Configuration
     anthropic_api_key: Optional[str] = Field(default=None, env="ANTHROPIC_API_KEY")
@@ -287,7 +287,7 @@ class AIConfig(BaseSettings):
                 "base_url": self.minimax_base_url,
                 "model": self.minimax_model,
                 "max_tokens": self.max_tokens,
-                "temperature": self.temperature,
+                "temperature": min(self.temperature, 1.0),
                 "top_p": self.top_p,
             },
             "anthropic": {
@@ -431,6 +431,15 @@ def reload_ai_config():
     ai_config.ai_302ai_api_key = os.environ.get('302AI_API_KEY', ai_config.ai_302ai_api_key)
     ai_config.ai_302ai_base_url = os.environ.get('302AI_BASE_URL', ai_config.ai_302ai_base_url)
     ai_config.ai_302ai_model = os.environ.get('302AI_MODEL', ai_config.ai_302ai_model)
+    ai_config.minimax_api_key = os.environ.get('MINIMAX_API_KEY', ai_config.minimax_api_key)
+    ai_config.minimax_base_url = os.environ.get('MINIMAX_BASE_URL', ai_config.minimax_base_url)
+    ai_config.minimax_model = os.environ.get('MINIMAX_MODEL', ai_config.minimax_model)
+    ai_config.deepseek_api_key = os.environ.get('DEEPSEEK_API_KEY', ai_config.deepseek_api_key)
+    ai_config.deepseek_base_url = os.environ.get('DEEPSEEK_BASE_URL', ai_config.deepseek_base_url)
+    ai_config.deepseek_model = os.environ.get('DEEPSEEK_MODEL', ai_config.deepseek_model)
+    ai_config.kimi_api_key = os.environ.get('KIMI_API_KEY', ai_config.kimi_api_key)
+    ai_config.kimi_base_url = os.environ.get('KIMI_BASE_URL', ai_config.kimi_base_url)
+    ai_config.kimi_model = os.environ.get('KIMI_MODEL', ai_config.kimi_model)
     ai_config.default_ai_provider = os.environ.get('DEFAULT_AI_PROVIDER', ai_config.default_ai_provider)
     model_provider_env = os.environ.get('DEFAULT_MODEL_PROVIDER')
     ai_config.default_model_provider = (ai_config._normalize_optional_str(model_provider_env)

--- a/src/landppt/services/config_service.py
+++ b/src/landppt/services/config_service.py
@@ -64,8 +64,8 @@ class ConfigService:
             "kimi_model": {"type": "text", "category": "ai_providers", "default": "kimi-k2.5"},
 
             "minimax_api_key": {"type": "password", "category": "ai_providers"},
-            "minimax_base_url": {"type": "url", "category": "ai_providers", "default": "https://api.minimaxi.com/v1"},
-            "minimax_model": {"type": "text", "category": "ai_providers", "default": "MiniMax-M2.1"},
+            "minimax_base_url": {"type": "url", "category": "ai_providers", "default": "https://api.minimax.io/v1"},
+            "minimax_model": {"type": "text", "category": "ai_providers", "default": "MiniMax-M2.7"},
             
             "anthropic_api_key": {"type": "password", "category": "ai_providers"},
             "anthropic_base_url": {"type": "url", "category": "ai_providers", "default": "https://api.anthropic.com"},
@@ -259,13 +259,15 @@ class ConfigService:
 
         # MiniMax: legacy base URL / model -> new defaults (only when API key not configured)
         if _is_empty_env("MINIMAX_API_KEY"):
-            if (os.getenv("MINIMAX_BASE_URL") or "").strip() == "https://api.minimax.chat/v1":
-                set_key(self.env_file, "MINIMAX_BASE_URL", "https://api.minimaxi.com/v1", quote_mode="never")
-                os.environ["MINIMAX_BASE_URL"] = "https://api.minimaxi.com/v1"
+            minimax_url = (os.getenv("MINIMAX_BASE_URL") or "").strip()
+            if minimax_url in ("https://api.minimax.chat/v1", "https://api.minimaxi.com/v1"):
+                set_key(self.env_file, "MINIMAX_BASE_URL", "https://api.minimax.io/v1", quote_mode="never")
+                os.environ["MINIMAX_BASE_URL"] = "https://api.minimax.io/v1"
                 updated = True
-            if (os.getenv("MINIMAX_MODEL") or "").strip() == "MiniMax-Text-01":
-                set_key(self.env_file, "MINIMAX_MODEL", "MiniMax-M2.1", quote_mode="never")
-                os.environ["MINIMAX_MODEL"] = "MiniMax-M2.1"
+            minimax_model = (os.getenv("MINIMAX_MODEL") or "").strip()
+            if minimax_model in ("MiniMax-Text-01", "MiniMax-M2.1"):
+                set_key(self.env_file, "MINIMAX_MODEL", "MiniMax-M2.7", quote_mode="never")
+                os.environ["MINIMAX_MODEL"] = "MiniMax-M2.7"
                 updated = True
 
         if updated:
@@ -300,13 +302,13 @@ class ConfigService:
                 config["kimi_model"] = "kimi-k2.5"
 
         if not (str(config.get("minimax_api_key") or "").strip()):
-            if (str(config.get("minimax_base_url") or "").strip()) in {"", "https://api.minimax.chat/v1"}:
-                config["minimax_base_url"] = "https://api.minimaxi.com/v1"
-            if (str(config.get("minimax_model") or "").strip()) in {"", "MiniMax-Text-01"}:
-                config["minimax_model"] = "MiniMax-M2.1"
+            if (str(config.get("minimax_base_url") or "").strip()) in {"", "https://api.minimax.chat/v1", "https://api.minimaxi.com/v1"}:
+                config["minimax_base_url"] = "https://api.minimax.io/v1"
+            if (str(config.get("minimax_model") or "").strip()) in {"", "MiniMax-Text-01", "MiniMax-M2.1"}:
+                config["minimax_model"] = "MiniMax-M2.7"
 
         return config
-    
+
     def get_config_by_category(self, category: str) -> Dict[str, Any]:
         """Get configuration values by category"""
         self._ensure_runtime_schema_extensions()
@@ -333,10 +335,10 @@ class ConfigService:
                     config["kimi_model"] = "kimi-k2.5"
 
             if not (str(config.get("minimax_api_key") or "").strip()):
-                if (str(config.get("minimax_base_url") or "").strip()) in {"", "https://api.minimax.chat/v1"}:
-                    config["minimax_base_url"] = "https://api.minimaxi.com/v1"
-                if (str(config.get("minimax_model") or "").strip()) in {"", "MiniMax-Text-01"}:
-                    config["minimax_model"] = "MiniMax-M2.1"
+                if (str(config.get("minimax_base_url") or "").strip()) in {"", "https://api.minimax.chat/v1", "https://api.minimaxi.com/v1"}:
+                    config["minimax_base_url"] = "https://api.minimax.io/v1"
+                if (str(config.get("minimax_model") or "").strip()) in {"", "MiniMax-Text-01", "MiniMax-M2.1"}:
+                    config["minimax_model"] = "MiniMax-M2.7"
         
         return config
     

--- a/src/landppt/web/templates/ai_config.html
+++ b/src/landppt/web/templates/ai_config.html
@@ -154,12 +154,12 @@
                                 <input type="hidden" name="302ai_base_url" value="https://api.302.ai/v1">
                                 <input type="text" value="https://api.302.ai/v1" disabled>
                                 {% else %}
-                                {% if (not provider_api_key) and provider == 'minimax' and (not provider_base_url or provider_base_url == 'https://api.minimax.chat/v1') %}
-                                    {% set provider_base_url = 'https://api.minimaxi.com/v1' %}
+                                {% if (not provider_api_key) and provider == 'minimax' and (not provider_base_url or provider_base_url in ['https://api.minimax.chat/v1', 'https://api.minimaxi.com/v1']) %}
+                                    {% set provider_base_url = 'https://api.minimax.io/v1' %}
                                 {% endif %}
                                 <input type="text" name="{{ provider }}_base_url"
                                     value="{{ provider_base_url }}"
-                                    placeholder="{% if provider == 'openai' %}https://api.openai.com/v1{% elif provider == 'deepseek' %}https://api.deepseek.com/v1{% elif provider == 'kimi' %}https://api.moonshot.cn/v1{% elif provider == 'minimax' %}https://api.minimaxi.com/v1{% else %}https://api.openai.com/v1{% endif %}">
+                                    placeholder="{% if provider == 'openai' %}https://api.openai.com/v1{% elif provider == 'deepseek' %}https://api.deepseek.com/v1{% elif provider == 'kimi' %}https://api.moonshot.cn/v1{% elif provider == 'minimax' %}https://api.minimax.io/v1{% else %}https://api.openai.com/v1{% endif %}">
                                 {% endif %}
                             </div>
 
@@ -177,13 +177,13 @@
                                     {% if not provider_api_key %}
                                         {% if provider == 'kimi' and (not provider_model or provider_model == 'moonshot-v1-8k') %}
                                             {% set provider_model = 'kimi-k2.5' %}
-                                        {% elif provider == 'minimax' and (not provider_model or provider_model == 'MiniMax-Text-01') %}
-                                            {% set provider_model = 'MiniMax-M2.1' %}
+                                        {% elif provider == 'minimax' and (not provider_model or provider_model in ['MiniMax-Text-01', 'MiniMax-M2.1']) %}
+                                            {% set provider_model = 'MiniMax-M2.7' %}
                                         {% endif %}
                                     {% endif %}
                                     <input type="text" name="{{ provider }}_model" id="{{ provider }}_model_input" class="model-input"
                                         value="{{ provider_model }}"
-                                        placeholder="{% if provider == 'openai' %}gpt-4o{% elif provider == 'deepseek' %}deepseek-chat{% elif provider == 'kimi' %}kimi-k2.5{% elif provider == 'minimax' %}MiniMax-M2.1{% elif provider == '302ai' %}gpt-4o{% else %}model{% endif %}">
+                                        placeholder="{% if provider == 'openai' %}gpt-4o{% elif provider == 'deepseek' %}deepseek-chat{% elif provider == 'kimi' %}kimi-k2.5{% elif provider == 'minimax' %}MiniMax-M2.7{% elif provider == '302ai' %}gpt-4o{% else %}model{% endif %}">
                                     {% if provider == "302ai" %}
                                     <button type="button" onclick="fetch302AIModels()" id="{{ provider }}_model_fetch_btn"
                                         class="model-fetch-btn" title="获取可用模型列表">
@@ -3337,13 +3337,13 @@
                 openai: 'https://api.openai.com/v1',
                 deepseek: 'https://api.deepseek.com/v1',
                 kimi: 'https://api.moonshot.cn/v1',
-                minimax: 'https://api.minimaxi.com/v1'
+                minimax: 'https://api.minimax.io/v1'
             };
             const defaultModels = {
                 openai: 'gpt-4o',
                 deepseek: 'deepseek-chat',
                 kimi: 'kimi-k2.5',
-                minimax: 'MiniMax-M2.1'
+                minimax: 'MiniMax-M2.7'
             };
 
             // 获取配置 - 使用前端页面填写的信息
@@ -4086,7 +4086,7 @@
                     openai: 'https://api.openai.com/v1',
                     deepseek: 'https://api.deepseek.com/v1',
                     kimi: 'https://api.moonshot.cn/v1',
-                    minimax: 'https://api.minimaxi.com/v1'
+                    minimax: 'https://api.minimax.io/v1'
                 };
 
                 const apiKeyInput = providerCard.querySelector(`input[name="${provider}_api_key"]`);
@@ -5082,7 +5082,7 @@
             openai: 'https://api.openai.com/v1',
             deepseek: 'https://api.deepseek.com/v1',
             kimi: 'https://api.moonshot.cn/v1',
-            minimax: 'https://api.minimaxi.com/v1'
+            minimax: 'https://api.minimax.io/v1'
         };
 
         try {

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,313 @@
+"""
+Tests for MiniMax provider configuration, factory registration,
+temperature clamping, and reload_ai_config() support.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Unit tests – configuration defaults
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxConfigDefaults:
+    """Verify that the AIConfig singleton ships the correct MiniMax defaults."""
+
+    def test_default_base_url(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key="test-key")
+        assert cfg.minimax_base_url == "https://api.minimax.io/v1"
+
+    def test_default_model(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key="test-key")
+        assert cfg.minimax_model == "MiniMax-M2.7"
+
+    def test_custom_model_via_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_MODEL", "MiniMax-M2.5-highspeed")
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key="test-key")
+        assert cfg.minimax_model == "MiniMax-M2.5-highspeed"
+
+    def test_custom_base_url_via_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_BASE_URL", "https://custom.proxy.example/v1")
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key="test-key")
+        assert cfg.minimax_base_url == "https://custom.proxy.example/v1"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – provider availability
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxProviderAvailability:
+    """Provider should be available only when an API key is configured."""
+
+    def test_available_with_api_key(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key="test-key")
+        assert cfg.is_provider_available("minimax") is True
+
+    def test_unavailable_without_api_key(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key=None)
+        assert cfg.is_provider_available("minimax") is False
+
+    def test_appears_in_available_list(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key="test-key")
+        providers = cfg.get_available_providers()
+        assert "minimax" in providers
+
+    def test_absent_from_available_list_without_key(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key=None)
+        providers = cfg.get_available_providers()
+        assert "minimax" not in providers
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – temperature clamping
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxTemperatureClamping:
+    """MiniMax API requires temperature <= 1.0."""
+
+    def test_temperature_clamped_to_1(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key="test-key", temperature=1.5)
+        config = cfg.get_provider_config("minimax")
+        assert config["temperature"] <= 1.0
+
+    def test_temperature_not_altered_when_valid(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key="test-key", temperature=0.7)
+        config = cfg.get_provider_config("minimax")
+        assert config["temperature"] == 0.7
+
+    def test_temperature_zero_allowed(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key="test-key", temperature=0.0)
+        config = cfg.get_provider_config("minimax")
+        assert config["temperature"] == 0.0
+
+    def test_openai_temperature_not_clamped(self):
+        """Other providers should not be affected by MiniMax clamping."""
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(openai_api_key="test-key", temperature=1.5)
+        config = cfg.get_provider_config("openai")
+        assert config["temperature"] == 1.5
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – get_provider_config contents
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxProviderConfig:
+    """Verify the dictionary returned by get_provider_config('minimax')."""
+
+    def test_config_keys(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key="test-key")
+        config = cfg.get_provider_config("minimax")
+        assert "api_key" in config
+        assert "base_url" in config
+        assert "model" in config
+        assert "max_tokens" in config
+        assert "temperature" in config
+
+    def test_config_values(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(minimax_api_key="test-key")
+        config = cfg.get_provider_config("minimax")
+        assert config["api_key"] == "test-key"
+        assert config["base_url"] == "https://api.minimax.io/v1"
+        assert config["model"] == "MiniMax-M2.7"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – model role resolution
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxRoleResolution:
+    """Role-based model config should resolve MiniMax correctly."""
+
+    def test_default_role_with_minimax_provider(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(
+            minimax_api_key="test-key",
+            default_ai_provider="minimax",
+        )
+        role_cfg = cfg.get_model_config_for_role("default")
+        assert role_cfg["provider"] == "minimax"
+        assert role_cfg["model"] == "MiniMax-M2.7"
+
+    def test_role_override_to_minimax(self):
+        from landppt.core.config import AIConfig
+
+        cfg = AIConfig(
+            minimax_api_key="test-key",
+            default_ai_provider="openai",
+        )
+        role_cfg = cfg.get_model_config_for_role("default", provider_override="minimax")
+        assert role_cfg["provider"] == "minimax"
+        assert role_cfg["model"] == "MiniMax-M2.7"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – reload_ai_config
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxReloadConfig:
+    """reload_ai_config() should pick up MiniMax env var changes."""
+
+    def test_reload_updates_minimax_model(self, monkeypatch):
+        from landppt.core.config import ai_config, reload_ai_config
+
+        monkeypatch.setenv("MINIMAX_MODEL", "MiniMax-M2.5")
+        reload_ai_config()
+        assert ai_config.minimax_model == "MiniMax-M2.5"
+
+    def test_reload_updates_minimax_base_url(self, monkeypatch):
+        from landppt.core.config import ai_config, reload_ai_config
+
+        monkeypatch.setenv("MINIMAX_BASE_URL", "https://proxy.example/v1")
+        reload_ai_config()
+        assert ai_config.minimax_base_url == "https://proxy.example/v1"
+
+    def test_reload_updates_minimax_api_key(self, monkeypatch):
+        from landppt.core.config import ai_config, reload_ai_config
+
+        monkeypatch.setenv("MINIMAX_API_KEY", "new-test-key")
+        reload_ai_config()
+        assert ai_config.minimax_api_key == "new-test-key"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – factory registration
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxFactoryRegistration:
+    """MiniMax must be registered in the AIProviderFactory."""
+
+    def test_minimax_in_factory_providers(self):
+        from landppt.ai.providers import AIProviderFactory
+
+        available = AIProviderFactory.get_available_providers()
+        assert "minimax" in available
+
+    def test_factory_creates_openai_provider(self):
+        from landppt.ai.providers import AIProviderFactory, OpenAIProvider
+
+        config = {
+            "api_key": "test-key",
+            "base_url": "https://api.minimax.io/v1",
+            "model": "MiniMax-M2.7",
+            "max_tokens": 16384,
+            "temperature": 0.7,
+            "top_p": 1.0,
+        }
+        provider = AIProviderFactory.create_provider("minimax", config)
+        assert isinstance(provider, OpenAIProvider)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests – MiniMax API calls (requires MINIMAX_API_KEY)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not set – skipping live API tests",
+)
+class TestMiniMaxIntegration:
+    """Live integration tests against the MiniMax API."""
+
+    @pytest.mark.asyncio
+    async def test_chat_completion(self):
+        from landppt.ai.providers import AIProviderFactory
+
+        config = {
+            "api_key": os.environ["MINIMAX_API_KEY"],
+            "base_url": "https://api.minimax.io/v1",
+            "model": "MiniMax-M2.7",
+            "max_tokens": 64,
+            "temperature": 0.7,
+            "top_p": 1.0,
+        }
+        provider = AIProviderFactory.create_provider("minimax", config)
+
+        from landppt.ai.base import AIMessage, MessageRole
+
+        messages = [AIMessage(role=MessageRole.USER, content="Say hello in one word.")]
+        response = await provider.chat_completion(messages)
+        assert response.content
+        assert len(response.content) > 0
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_completion(self):
+        from landppt.ai.providers import AIProviderFactory
+
+        config = {
+            "api_key": os.environ["MINIMAX_API_KEY"],
+            "base_url": "https://api.minimax.io/v1",
+            "model": "MiniMax-M2.7",
+            "max_tokens": 64,
+            "temperature": 0.7,
+            "top_p": 1.0,
+        }
+        provider = AIProviderFactory.create_provider("minimax", config)
+
+        from landppt.ai.base import AIMessage, MessageRole
+
+        messages = [AIMessage(role=MessageRole.USER, content="Say hello in one word.")]
+        chunks = []
+        async for chunk in provider.stream_chat_completion(messages):
+            chunks.append(chunk)
+        full = "".join(chunks)
+        assert len(full) > 0
+
+    @pytest.mark.asyncio
+    async def test_temperature_zero(self):
+        """MiniMax should accept temperature=0."""
+        from landppt.ai.providers import AIProviderFactory
+
+        config = {
+            "api_key": os.environ["MINIMAX_API_KEY"],
+            "base_url": "https://api.minimax.io/v1",
+            "model": "MiniMax-M2.7",
+            "max_tokens": 32,
+            "temperature": 0.0,
+            "top_p": 1.0,
+        }
+        provider = AIProviderFactory.create_provider("minimax", config)
+
+        from landppt.ai.base import AIMessage, MessageRole
+
+        messages = [AIMessage(role=MessageRole.USER, content="Reply OK.")]
+        response = await provider.chat_completion(messages)
+        assert response.content


### PR DESCRIPTION
## Summary

- **Fix API endpoint**: Update MiniMax base URL from the deprecated `api.minimaxi.com` to the current `api.minimax.io`
- **Upgrade default model**: MiniMax-M2.1 to MiniMax-M2.7 (latest, 1M context window)
- **Add temperature clamping**: MiniMax API requires temperature <= 1.0; `get_provider_config()` now clamps automatically
- **Fix `reload_ai_config()`**: MiniMax, DeepSeek, and Kimi environment variables were not being reloaded, now fixed
- **Update legacy migration**: Old URLs (`api.minimax.chat`, `api.minimaxi.com`) and old models (`MiniMax-Text-01`, `MiniMax-M2.1`) auto-upgrade to current values
- **Update frontend**: All JS defaults and template placeholders updated

## Available MiniMax Models

| Model | Context | Notes |
|-------|---------|-------|
| MiniMax-M2.7 | 1M tokens | Latest flagship model |
| MiniMax-M2.7-highspeed | 1M tokens | Faster variant |
| MiniMax-M2.5 | 204K tokens | Previous generation |
| MiniMax-M2.5-highspeed | 204K tokens | Previous gen, faster |

## Files Changed (7 files)

- `src/landppt/core/config.py` -- Default URL/model, temperature clamping, reload fix
- `src/landppt/services/config_service.py` -- Legacy migration paths
- `src/landppt/web/templates/ai_config.html` -- Frontend placeholders and defaults
- `.env.example` -- Updated config with model list comment
- `README.md` / `README_EN.md` -- Updated documentation
- `tests/test_minimax_provider.py` -- 21 unit + 3 integration tests

## Test Plan

- [x] 21 unit tests pass (config defaults, availability, temperature clamping, provider config, role resolution, reload, factory registration)
- [x] 3 integration tests pass against live MiniMax API (chat completion, streaming, temperature=0)
- [ ] Manual: verify MiniMax provider works in the web UI settings page
