### PR TITLE
Security: Stored XSS via untrusted HTML rendered with `|safe`

### DIFF
--- a/src/landppt/web/templates/upload_result.html
+++ b/src/landppt/web/templates/upload_result.html
@@ -45,7 +45,7 @@
     <h3 style="color: #2c3e50; margin-bottom: 20px;">📄 提取的内容预览</h3>
     <div style="background: #f8f9fa; padding: 25px; border-radius: 10px; border-left: 4px solid #3498db;">
         <div style="max-height: 400px; overflow-y: auto; font-family: 'Courier New', monospace; line-height: 1.6; color: #2c3e50;">
-            {{ processed_content | replace('\n', '<br>') | safe }}
+            {{ processed_content }}
         </div>
         {% if processed_content | length > 500 %}
         <p style="margin-top: 15px; color: #7f8c8d; font-style: italic;">


### PR DESCRIPTION
## Problem

The template renders `processed_content` with `|safe` after only replacing newlines. If uploaded/processed file content contains HTML/JS payloads, it will be injected into the page and executed in the user's browser.

**Severity**: `high`
**File**: `src/landppt/web/templates/upload_result.html`

## Solution

Remove `|safe` for untrusted content and rely on default escaping. If formatting is required, sanitize server-side with a strict HTML allowlist (e.g., bleach) before rendering.

## Changes

- `src/landppt/web/templates/upload_result.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
