### PR TITLE
Security: XSS risk from embedding dynamic HTML in `iframe srcdoc`

### DIFF
--- a/src/landppt/web/templates/result.html
+++ b/src/landppt/web/templates/result.html
@@ -86,7 +86,8 @@
     <h3 style="color: #2c3e50; margin-bottom: 20px; text-align: center;">🎬 PPT 预览</h3>
     <div style="border: 2px solid #ecf0f1; border-radius: 10px; overflow: hidden; background: white;">
         <iframe 
-            srcdoc="{{ slides_html | replace('"', '&quot;') }}" 
+            src="/preview/{{ task_id }}"
+            sandbox
             style="width: 100%; height: 600px; border: none;"
             title="PPT Preview">
         </iframe>


### PR DESCRIPTION
## Problem

The template injects `slides_html` directly into `srcdoc`. Replacing only double quotes does not neutralize script/event-handler payloads. Malicious slide content can execute JS in an iframe context and potentially interact with same-origin resources.

**Severity**: `high`
**File**: `src/landppt/web/templates/result.html`

## Solution

Do not place unsanitized HTML into `srcdoc`. Sanitize `slides_html` with a strict allowlist, add iframe sandboxing (`sandbox` without `allow-same-origin` unless required), or render trusted static files instead.

## Changes

- `src/landppt/web/templates/result.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
