### PR TITLE
Fix outline resume flow and PPTX export config

### DIFF
--- a/src/landppt/api/landppt_api.py
+++ b/src/landppt/api/landppt_api.py
@@ -579,12 +579,25 @@ async def continue_from_stage(
         if not success:
             raise HTTPException(status_code=400, detail="Failed to reset stages")
 
-        # Start workflow from the specified stage
-        await user_ppt_service.start_workflow_from_stage(project_id, stage_id, user_id=user.id)
+        workflow_ready = await user_ppt_service.start_workflow_from_stage(
+            project_id, stage_id, user_id=user.id
+        )
+        if not workflow_ready:
+            raise HTTPException(status_code=400, detail="Failed to prepare workflow stage")
+
+        if stage_id == "outline_generation":
+            return {
+                "status": "ready",
+                "action": "start_outline_stream",
+                "message": "Outline generation stage reset. Start the outline stream to continue.",
+                "project_id": project_id,
+                "stage_id": stage_id,
+                "stream_url": f"/projects/{project_id}/outline-stream?force_regenerate=1",
+            }
 
         return {
             "status": "success",
-            "message": f"Workflow restarted from stage: {stage_id}",
+            "message": f"Workflow stage prepared: {stage_id}",
             "project_id": project_id,
             "stage_id": stage_id
         }

--- a/src/landppt/services/outline/project_outline_streaming_service.py
+++ b/src/landppt/services/outline/project_outline_streaming_service.py
@@ -297,6 +297,14 @@ class ProjectOutlineStreamingService:
             project = await self.project_manager.get_project(project_id)
             if not project:
                 raise ValueError('Project not found')
+            await self.project_manager.update_project_status(project_id, 'in_progress')
+            await self.project_manager.update_stage_status(
+                project_id,
+                'outline_generation',
+                'running',
+                0.0,
+                {'started_at': time.time(), 'message': 'Outline generation started'},
+            )
             from ..file_outline_utils import extract_saved_file_outline, should_force_file_outline_regeneration
             force_file_outline_regeneration = should_force_file_outline_regeneration(project.confirmed_requirements or {})
             ignore_saved_outline = bool(force_regenerate or force_file_outline_regeneration)
@@ -359,7 +367,6 @@ class ProjectOutlineStreamingService:
                 await self._update_outline_generation_stage(project_id, existing_outline)
                 yield f"data: {json.dumps({'done': True, 'llm_call_count': 0})}\n\n"
                 return
-            await self.project_manager.update_project_status(project_id, 'in_progress')
             if project.todo_board:
                 for stage in project.todo_board.stages:
                     if stage.id == 'outline_generation':
@@ -434,6 +441,13 @@ class ProjectOutlineStreamingService:
                 content = content.strip()
                 if not content or len(content.strip()) < 10:
                     error_message = 'AI生成的内容为空或过短，请重新生成大纲。'
+                    await self.project_manager.update_stage_status(
+                        project_id,
+                        'outline_generation',
+                        'failed',
+                        0.0,
+                        {'failed_at': time.time(), 'message': error_message},
+                    )
                     yield f"data: {json.dumps({'error': error_message})}\n\n"
                     return
             except Exception as ai_error:
@@ -444,6 +458,13 @@ class ProjectOutlineStreamingService:
                     error_message = 'AI服务暂时不可用，请稍后重新生成大纲。'
                 else:
                     error_message = f'AI生成大纲失败：{str(ai_error)}。请重新生成大纲。'
+                await self.project_manager.update_stage_status(
+                    project_id,
+                    'outline_generation',
+                    'failed',
+                    0.0,
+                    {'failed_at': time.time(), 'message': error_message},
+                )
                 yield f"data: {json.dumps({'error': error_message})}\n\n"
                 return
             structured_outline = None
@@ -493,6 +514,13 @@ class ProjectOutlineStreamingService:
                 logger.error(f'Failed to parse AI response as JSON: {parse_error}')
                 logger.error(f'AI response content: {content[:500]}...')
                 error_message = f'AI生成的大纲格式无效，无法解析。请重新生成大纲。'
+                await self.project_manager.update_stage_status(
+                    project_id,
+                    'outline_generation',
+                    'failed',
+                    0.0,
+                    {'failed_at': time.time(), 'message': error_message},
+                )
                 yield f"data: {json.dumps({'error': error_message})}\n\n"
                 return
         except Exception as e:
@@ -501,4 +529,18 @@ class ProjectOutlineStreamingService:
                 error_message = f'AI服务暂时不可用：{str(e)}。请稍后重试或检查网络连接。'
             else:
                 error_message = f'生成大纲时出现错误：{str(e)}'
+            try:
+                await self.project_manager.update_stage_status(
+                    project_id,
+                    'outline_generation',
+                    'failed',
+                    0.0,
+                    {'failed_at': time.time(), 'message': error_message},
+                )
+            except Exception as stage_error:
+                logger.warning(
+                    'Failed to mark outline generation failed for project %s: %s',
+                    project_id,
+                    stage_error,
+                )
             yield f"data: {json.dumps({'error': error_message})}\n\n"

--- a/src/landppt/services/pdf_to_pptx_converter.py
+++ b/src/landppt/services/pdf_to_pptx_converter.py
@@ -190,18 +190,18 @@ class PDFToPPTXConverter:
         self.sdk_manager = SDKDownloadManager(lib_dir)
 
     def set_user_id(self, user_id: int):
-        """Set user ID for loading user-specific configuration (sync version - use set_user_id_async in async context)"""
+        """Set user ID for task ownership context; Apryse licensing remains system-scoped."""
         self.user_id = user_id
-        self._cached_license_key = None  # Clear cache when user changes
-        self._sdk_initialized = False  # Force reinitialize with new license
+        self._cached_license_key = None  # Refresh the system license cache for the next conversion.
+        self._sdk_initialized = False  # Force reinitialize with the current system license.
     async def set_user_id_async(self, user_id: int):
-        """Set user ID and pre-load license key from database (async version - use this in async routes)"""
+        """Set user ID and pre-load the system Apryse Server SDK license key."""
         logger.info(f"set_user_id_async called with user_id={user_id}")
         self.user_id = user_id
         self._cached_license_key = None
         self._sdk_initialized = False
         
-        # Pre-load the license key from user config
+        # Pre-load the system license key for the worker subprocess.
         try:
             license_key = await self._get_license_key_async()
             self._cached_license_key = license_key
@@ -210,56 +210,50 @@ class PDFToPPTXConverter:
                 masked_key = f"{license_key[:4]}...{license_key[-4:]}"
             else:
                 masked_key = "***"
-            logger.info(f"Pre-loaded Apryse license key for user {user_id}: {masked_key}")
+            logger.info(f"Pre-loaded system Apryse Server SDK license key: {masked_key}")
         except Exception as e:
             logger.warning(f"Failed to pre-load Apryse license key: {e}")
     
     async def _get_license_key_async(self) -> str:
-        """Get license key from user database config (async version)"""
+        """Get the system Apryse Server SDK license key (async version)."""
         from ..core.config import ai_config
-        
-        logger.debug(f"_get_license_key_async: user_id={self.user_id}")
-        
-        if self.user_id is not None:
-            try:
-                from .db_config_service import get_db_config_service
-                config_service = get_db_config_service()
-                user_config = await config_service.get_all_config(user_id=self.user_id)
-                
-                license_key = user_config.get("apryse_license_key")
-                logger.info(f"Loaded apryse_license_key from user config: {'found' if license_key else 'not found'}")
-                if license_key:
-                    return license_key
-            except Exception as e:
-                logger.warning(f"Failed to load Apryse license from user config: {e}")
+
+        try:
+            from .db_config_service import get_db_config_service
+            config_service = get_db_config_service()
+            system_config = await config_service.get_all_config(user_id=None)
+
+            license_key = system_config.get("apryse_license_key")
+            logger.info(f"Loaded system apryse_license_key: {'found' if license_key else 'not found'}")
+            if license_key:
+                return license_key
+        except Exception as e:
+            logger.warning(f"Failed to load system Apryse license from DB config: {e}")
         
         # Fallback to global config
         fallback_key = ai_config.apryse_license_key or 'your_apryse_license_key_here'
-        logger.info(f"Using fallback Apryse license key from global config")
+        logger.info("Using fallback Apryse license key from global config")
         return fallback_key
 
     @property
     def license_key(self):
-        """Dynamically get license key to ensure latest config"""
+        """Dynamically get the system Apryse Server SDK license key."""
         # Try to use cached license key first
         if self._cached_license_key:
             return self._cached_license_key
             
         from ..core.config import ai_config
         
-        # For sync context, try to read from user config if user_id is set
-        if self.user_id is not None:
-            try:
-                from .db_config_service import get_db_config_service
+        try:
+            from .db_config_service import get_db_config_service
 
-                config_service = get_db_config_service()
-                license_key = config_service.get_config_value_sync("apryse_license_key", user_id=self.user_id)
-                if license_key:
-                    self._cached_license_key = license_key
-                    return license_key
-            except Exception as e:
-                import logging
-                logging.getLogger(__name__).warning(f"Failed to load Apryse license from user config: {e}")
+            config_service = get_db_config_service()
+            license_key = config_service.get_config_value_sync("apryse_license_key", user_id=None)
+            if license_key:
+                self._cached_license_key = license_key
+                return license_key
+        except Exception as e:
+            logging.getLogger(__name__).warning(f"Failed to load system Apryse license from DB config: {e}")
         
         return ai_config.apryse_license_key or 'your_apryse_license_key_here'
     
@@ -339,7 +333,7 @@ class PDFToPPTXConverter:
     def reload_config(self):
         """Reload configuration and reinitialize SDK if needed"""
         logger.info("Reloading PDF to PPTX converter configuration...")
-        # Force reinitialization with new license key
+        # Force reinitialization with the current system license key.
         self._sdk_initialized = False
         return self._initialize_sdk()
     

--- a/src/landppt/services/project_workflow_stage_service.py
+++ b/src/landppt/services/project_workflow_stage_service.py
@@ -720,14 +720,28 @@ class ProjectWorkflowStageService:
                     logger.error(f"Cannot start from stage {stage_id}: requirements not confirmed")
                     return False
 
-                # Start the workflow from the specified stage
-                # This will be handled by the existing workflow execution logic
-                # For now, just mark the stage as ready to start
+                # The browser owns long-running streaming generation. This method
+                # only prepares the stage so the caller can start the right stream.
                 await self.project_manager.update_stage_status(
-                    project_id, stage_id, "pending", 0.0
+                    project_id,
+                    stage_id,
+                    "pending",
+                    0.0,
+                    {
+                        "prepared_at": time.time(),
+                        "action": (
+                            "start_outline_stream"
+                            if stage_id == "outline_generation"
+                            else "start_stage"
+                        ),
+                    },
+                    user_id=user_id,
                 )
 
-                logger.info(f"Workflow ready to start from stage {stage_id} for project {project_id}")
+                logger.info(
+                    f"Workflow stage {stage_id} prepared for project {project_id}; "
+                    "caller must start the execution stream"
+                )
                 return True
 
             except Exception as e:

--- a/src/landppt/web/route_modules/export_routes.py
+++ b/src/landppt/web/route_modules/export_routes.py
@@ -295,7 +295,7 @@ async def export_project_pptx(
         if not project.slides_data or len(project.slides_data) == 0:
             raise HTTPException(status_code=400, detail="PPT not generated yet")
 
-        # Pre-load user's license key (async, fast operation)
+        # Pre-load the system Apryse Server SDK license key (async, fast operation)
         converter = get_pdf_to_pptx_converter()
         await converter.set_user_id_async(user.id)
         

--- a/src/landppt/web/route_modules/outline_generation_routes.py
+++ b/src/landppt/web/route_modules/outline_generation_routes.py
@@ -87,7 +87,26 @@ async def stream_outline_generation(
         if not has_credits:
             async def generate():
                 import json
-                yield f"data: {json.dumps({'error': f'积分不足，大纲生成需要 {required} 积分，当前余额 {balance} 积分'})}\n\n"
+                error_message = f"积分不足，大纲生成需要 {required} 积分，当前余额 {balance} 积分"
+                try:
+                    await user_ppt_service.project_manager.update_stage_status(
+                        project_id,
+                        "outline_generation",
+                        "failed",
+                        0.0,
+                        {
+                            "failed_at": time.time(),
+                            "message": error_message,
+                        },
+                        user_id=user.id,
+                    )
+                except Exception as stage_error:
+                    logger.warning(
+                        "Failed to mark outline generation failed for project %s: %s",
+                        project_id,
+                        stage_error,
+                    )
+                yield f"data: {json.dumps({'error': error_message}, ensure_ascii=False)}\n\n"
             return StreamingResponse(
                 generate(),
                 media_type="text/event-stream",
@@ -100,8 +119,11 @@ async def stream_outline_generation(
 
         async def generate():
             billed = False
+            done_seen = False
             content_source = confirmed_requirements.get("content_source")
             force_fresh_generation = bool(force_regenerate or force_file_outline_regeneration)
+            stage_started = False
+            failed_recorded = False
             if force_fresh_generation:
                 logger.info(
                     "Project %s outline stream requested fresh regeneration; skipping reusable outline branches",
@@ -113,6 +135,29 @@ async def stream_outline_generation(
             )
 
             try:
+                try:
+                    await user_ppt_service.project_manager.update_project_status(
+                        project_id, "in_progress", user_id=user.id
+                    )
+                    await user_ppt_service.project_manager.update_stage_status(
+                        project_id,
+                        "outline_generation",
+                        "running",
+                        0.0,
+                        {
+                            "started_at": time.time(),
+                            "message": "Outline generation started",
+                        },
+                        user_id=user.id,
+                    )
+                    stage_started = True
+                except Exception as stage_error:
+                    logger.warning(
+                        "Failed to mark outline generation running for project %s: %s",
+                        project_id,
+                        stage_error,
+                    )
+
                 chunk_source = user_ppt_service.generate_outline_streaming(
                     project_id,
                     force_regenerate=force_fresh_generation,
@@ -134,18 +179,43 @@ async def stream_outline_generation(
                     )
 
                 async for chunk in chunk_source:
-                    yield chunk
-                    if billed or not _is_billable_provider(outline_provider_name):
-                        continue
+                    payloads = []
                     for line in str(chunk).splitlines():
                         if not line.startswith("data: "):
                             continue
                         try:
-                            import json
-                            payload = json.loads(line[6:])
+                            payloads.append(json.loads(line[6:]))
                         except Exception:
                             continue
+
+                    for payload in payloads:
+                        if payload.get("error") and stage_started and not failed_recorded:
+                            failed_recorded = True
+                            try:
+                                await user_ppt_service.project_manager.update_stage_status(
+                                    project_id,
+                                    "outline_generation",
+                                    "failed",
+                                    0.0,
+                                    {
+                                        "failed_at": time.time(),
+                                        "message": str(payload.get("error")),
+                                    },
+                                    user_id=user.id,
+                                )
+                            except Exception as stage_error:
+                                logger.warning(
+                                    "Failed to mark outline generation failed for project %s: %s",
+                                    project_id,
+                                    stage_error,
+                                )
+
+                    yield chunk
+                    if billed or not _is_billable_provider(outline_provider_name):
+                        continue
+                    for payload in payloads:
                         if payload.get("done") is True:
+                            done_seen = True
                             billed = True
                             llm_call_count = payload.get("llm_call_count", 1)
                             try:
@@ -163,7 +233,25 @@ async def stream_outline_generation(
                                     provider_name=outline_provider_name,
                                 )
             except Exception as e:
-                import json
+                if stage_started and not done_seen:
+                    try:
+                        await user_ppt_service.project_manager.update_stage_status(
+                            project_id,
+                            "outline_generation",
+                            "failed",
+                            0.0,
+                            {
+                                "failed_at": time.time(),
+                                "message": str(e),
+                            },
+                            user_id=user.id,
+                        )
+                    except Exception as stage_error:
+                        logger.warning(
+                            "Failed to mark outline generation failed for project %s: %s",
+                            project_id,
+                            stage_error,
+                        )
                 error_response = {'error': str(e)}
                 yield f"data: {json.dumps(error_response)}\n\n"
 

--- a/src/landppt/web/route_modules/project_workspace_routes.py
+++ b/src/landppt/web/route_modules/project_workspace_routes.py
@@ -14,6 +14,7 @@ from fastapi.responses import FileResponse, HTMLResponse
 from ...auth.middleware import get_current_user_required
 from ...core.config import ai_config, app_config
 from ...database.models import User
+from .export_support import _is_standard_pptx_export_enabled
 from .support import _apply_no_store_headers, logger, ppt_service, templates
 
 router = APIRouter()
@@ -171,12 +172,14 @@ async def edit_project_ppt(
             project.slides_data = []
 
         has_speech_scripts, narration_languages = await _resolve_project_narration_state(project_id, user.id)
+        standard_pptx_export_enabled = await _is_standard_pptx_export_enabled()
         response = templates.TemplateResponse(
             "pages/project/project_slides_editor.html",
             {
                 "request": request,
                 "project": project,
                 "enable_auto_layout_repair": ai_config.enable_auto_layout_repair,
+                "standard_pptx_export_enabled": standard_pptx_export_enabled,
                 "narration_video_tools_enabled": bool(getattr(user, "is_admin", False)) and getattr(app_config, "narration_video_tools_enabled", True),
                 "has_speech_scripts": has_speech_scripts,
                 "narration_languages": narration_languages,

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js
@@ -1,3 +1,59 @@
+const AI_STREAM_SUMMARY_MAX_CHARS = 180;
+
+function sanitizeAIStreamSummary(text) {
+    if (!text) return '';
+
+    return String(text)
+        .replace(/```(?:html)?[\s\S]*?```/gi, ' ')
+        .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+        .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+        .replace(/<!doctype[\s\S]*?>/gi, ' ')
+        .replace(/<html[\s\S]*?<\/html>/gi, ' ')
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/&lt;[\s\S]*?&gt;/gi, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function buildAIStreamSummary(text) {
+    const summary = sanitizeAIStreamSummary(text);
+    if (!summary) return '';
+    if (summary.length <= AI_STREAM_SUMMARY_MAX_CHARS) return summary;
+    return `${summary.slice(0, AI_STREAM_SUMMARY_MAX_CHARS)}...`;
+}
+
+function buildAIStreamStatusMessage(fullResponse, phase = 'streaming', hasHtmlContent = false) {
+    let statusText = '正在分析需求并生成修改方案...';
+
+    if (phase === 'start') {
+        statusText = '正在连接 AI 编辑服务...';
+    } else if (phase === 'complete') {
+        statusText = hasHtmlContent
+            ? '已生成修改内容。完整 HTML 已准备好，可应用更改或预览。'
+            : 'AI 回复已完成，正在尝试提取可应用的 HTML。';
+    } else if (/<html|```html|<style|<div/i.test(fullResponse || '')) {
+        statusText = '正在生成修改内容，已检测到 HTML 片段...';
+    }
+
+    const summary = buildAIStreamSummary(fullResponse);
+    return summary ? `${statusText}\n\n摘要：${summary}` : statusText;
+}
+
+function renderAIStreamStatus(aiMessageDiv, fullResponse, phase = 'streaming', hasHtmlContent = false) {
+    if (!aiMessageDiv) return '';
+
+    const statusText = buildAIStreamStatusMessage(fullResponse, phase, hasHtmlContent);
+    window.projectSlidesEditorPretext.setAssistantMessageText(aiMessageDiv, statusText);
+
+    const messagesContainer = document.getElementById('aiChatMessages');
+    if (messagesContainer) {
+        messagesContainer.scrollTop = messagesContainer.scrollHeight;
+    }
+
+    return statusText;
+}
+
 async function handleStreamingResponse(response, waitingDiv) {
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
@@ -30,12 +86,13 @@ async function handleStreamingResponse(response, waitingDiv) {
                                 streamingMessageId = 'ai-streaming-message-' + Date.now();
                                 aiMessageDiv = addAIMessage('', 'assistant', streamingMessageId);
                                 if (aiMessageDiv) aiMessageDiv.dataset.complete = 'false';
+                                renderAIStreamStatus(aiMessageDiv, fullResponse, 'start');
                             } else if (data.type === 'content' && data.content) {
                                 // 追加内容到AI消息
                                 fullResponse += data.content;
                                 if (aiMessageDiv) {
                                     // 转义HTML标签，防止实时渲染
-                                    window.projectSlidesEditorPretext.setAssistantMessageText(aiMessageDiv, fullResponse);
+                                    renderAIStreamStatus(aiMessageDiv, fullResponse, 'streaming');
                                     // 滚动到底部
                                     const messagesContainer = document.getElementById('aiChatMessages');
                                     messagesContainer.scrollTop = messagesContainer.scrollHeight;
@@ -45,7 +102,10 @@ async function handleStreamingResponse(response, waitingDiv) {
                                 newHtmlContent = data.newHtmlContent;
                                 fullResponse = data.fullResponse || fullResponse;
                                 if (streamingMessageId) {
-                                    updateAIChatHistoryMessage(streamingMessageId, fullResponse);
+                                    updateAIChatHistoryMessage(
+                                        streamingMessageId,
+                                        buildAIStreamStatusMessage(fullResponse, 'complete', !!newHtmlContent)
+                                    );
                                 }
                                 if (aiMessageDiv) aiMessageDiv.dataset.complete = 'true';
 
@@ -55,15 +115,13 @@ async function handleStreamingResponse(response, waitingDiv) {
 
                                 if (newHtmlContent) {
                                     console.log('✅ 检测到HTML内容，准备添加按钮');
-                                    console.log('📄 HTML内容预览:', newHtmlContent.substring(0, 200));
                                 } else {
                                     console.warn('⚠️  未检测到HTML内容');
-                                    console.log('📝 完整AI响应预览:', fullResponse ? fullResponse.substring(0, 500) : '无响应内容');
                                 }
 
                                 // 确保最终内容正确显示，转义HTML标签
                                 if (aiMessageDiv) {
-                                    window.projectSlidesEditorPretext.setAssistantMessageText(aiMessageDiv, fullResponse);
+                                    renderAIStreamStatus(aiMessageDiv, fullResponse, 'complete', !!newHtmlContent);
                                 }
 
                                 // 如果有HTML内容，添加应用按钮

--- a/src/landppt/web/templates/components/project/todo_board/extra_js_1.html
+++ b/src/landppt/web/templates/components/project/todo_board/extra_js_1.html
@@ -791,6 +791,10 @@
         }
     }
 
+    function isOutlineStageReadyToStart(statusText) {
+        return ['⏳', '✗', '✕'].includes((statusText || '').trim());
+    }
+
     // Show outline section
     function showOutlineSection() {
         // Create and show outline section if it doesn't exist
@@ -1583,6 +1587,7 @@
                             showOutlineGenerationError(data.error || '未知错误', 'regenerateOutlineNew');
                             if (cursorDiv) cursorDiv.style.display = 'none';
                             destroyOutlineStreamPreviewRenderers();
+                            outlineGenerationStarted = false;
                             return;
                         }
 
@@ -1711,6 +1716,7 @@
             showOutlineGenerationError(error.message || '连接失败', 'regenerateOutlineNew');
             if (cursorDiv) cursorDiv.style.display = 'none';
             destroyOutlineStreamPreviewRenderers();
+            outlineGenerationStarted = false;
         }
     }
 
@@ -2961,8 +2967,20 @@
             if (response.ok) {
                 const result = await response.json();
 
+                if (stageId === 'outline_generation' || result.action === 'start_outline_stream') {
+                    alert(`已从"${getStageDisplayName(stageId)}"步骤重新开始，正在生成大纲...`);
+
+                    outlineGenerationStarted = false;
+                    await updateStageStatusSilent('outline_generation', 'running', 0);
+                    showOutlineSection();
+                    setTimeout(() => {
+                        startOutlineGenerationNew({ forceRegenerate: true });
+                    }, 300);
+                    return;
+                }
+
                 // Show success message
-                alert(`已从"${getStageDisplayName(stageId)}"步骤重新开始，正在重新执行工作流程...`);
+                alert(`已从"${getStageDisplayName(stageId)}"步骤重新开始。`);
 
                 // Reload page to show updated status
                 setTimeout(() => {
@@ -3090,7 +3108,7 @@
                             if (stage.id === 'requirements_confirmation') {
                                 const outlineStage = document.querySelector('[data-stage-id="outline_generation"]');
                                 const outlineStatus = outlineStage?.querySelector('.stage-status-icon')?.textContent;
-                                if (outlineStatus === '⏳') {
+                                if (isOutlineStageReadyToStart(outlineStatus)) {
                                     console.log('Requirements just completed, starting outline generation');
                                     setTimeout(() => {
                                         startStageExecution('outline_generation');
@@ -3177,11 +3195,10 @@
         }
 
         // Auto-start outline generation if requirements just confirmed or if requirements completed and outline pending
-        if ((fromRequirements || requirementsCompleted) && outlineStatus === '⏳') {
+        if ((fromRequirements || requirementsCompleted) && isOutlineStageReadyToStart(outlineStatus)) {
             // Requirements confirmed, automatically start outline generation (second step)
             console.log('Requirements confirmed, starting outline generation automatically');
-            // 只有在不是来自需求确认页面时才调用，避免重复调用
-            if (!fromRequirements) {
+            if (!outlineGenerationStarted) {
                 setTimeout(() => {
                     startOutlineGenerationNew();
                 }, 1000);

--- a/tests/test_project_workflow_regressions.py
+++ b/tests/test_project_workflow_regressions.py
@@ -90,6 +90,54 @@ async def test_rename_project_rejects_blank_title():
 
 
 @pytest.mark.asyncio
+async def test_continue_from_outline_stage_returns_stream_action(monkeypatch):
+    from landppt.api import landppt_api
+
+    calls = []
+
+    class FakeRequest:
+        async def json(self):
+            return {"stage_id": "outline_generation"}
+
+    class FakeProjectManager:
+        async def get_project(self, project_id, user_id=None):
+            calls.append(("get_project", project_id, user_id))
+            return SimpleNamespace(project_id=project_id, confirmed_requirements={"topic": "demo"})
+
+    class FakePPTService:
+        project_manager = FakeProjectManager()
+
+        async def reset_stages_from(self, project_id, stage_id, user_id=None):
+            calls.append(("reset", project_id, stage_id, user_id))
+            return True
+
+        async def start_workflow_from_stage(self, project_id, stage_id, user_id=None):
+            calls.append(("prepare", project_id, stage_id, user_id))
+            return True
+
+    monkeypatch.setattr(
+        landppt_api,
+        "get_ppt_service_for_user",
+        lambda user_id: FakePPTService(),
+    )
+
+    response = await landppt_api.continue_from_stage(
+        "project-1",
+        FakeRequest(),
+        user=SimpleNamespace(id=11),
+    )
+
+    assert response["status"] == "ready"
+    assert response["action"] == "start_outline_stream"
+    assert response["stream_url"] == "/projects/project-1/outline-stream?force_regenerate=1"
+    assert calls == [
+        ("get_project", "project-1", 11),
+        ("reset", "project-1", "outline_generation", 11),
+        ("prepare", "project-1", "outline_generation", 11),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_enhanced_ppt_service_keeps_project_workflow_proxy():
     execute_project_workflow = _load_class_method(
         "src/landppt/services/enhanced_ppt_service.py",
@@ -275,3 +323,42 @@ def test_editor_sidebar_thumbnail_refresh_recalculates_scale_without_overriding_
     assert "aspect-ratio: 16 / 9;" in css
     assert "height: 95px" not in css
     assert "scale(0.1875)" in css
+
+
+def test_continue_outline_stage_starts_real_outline_stream():
+    api = _read("src/landppt/api/landppt_api.py")
+    script = _read("src/landppt/web/templates/components/project/todo_board/extra_js_1.html")
+
+    assert '"action": "start_outline_stream"' in api
+    assert 'stream_url": f"/projects/{project_id}/outline-stream?force_regenerate=1"' in api
+    assert "result.action === 'start_outline_stream'" in script
+    assert "startOutlineGenerationNew({ forceRegenerate: true })" in script
+
+
+def test_outline_generation_failures_are_not_left_running_or_pending():
+    route = _read("src/landppt/web/route_modules/outline_generation_routes.py")
+    streaming_service = _read("src/landppt/services/outline/project_outline_streaming_service.py")
+    script = _read("src/landppt/web/templates/components/project/todo_board/extra_js_1.html")
+
+    assert '"outline_generation",\n                        "running"' in route
+    assert '"outline_generation",\n                                    "failed"' in route
+    assert "'outline_generation',\n                        'failed'" in streaming_service
+    assert "outlineGenerationStarted = false;" in script
+
+
+def test_requirements_return_auto_start_no_longer_skips_outline_stream():
+    script = _read("src/landppt/web/templates/components/project/todo_board/extra_js_1.html")
+
+    assert "function isOutlineStageReadyToStart(statusText)" in script
+    assert "['⏳', '✗', '✕'].includes" in script
+
+    auto_start_block = script[
+        script.index(
+            "if ((fromRequirements || requirementsCompleted) && isOutlineStageReadyToStart(outlineStatus))"
+        )
+        : script.index("} else if (!requirementsCompleted)")
+    ]
+
+    assert "startOutlineGenerationNew();" in auto_start_block
+    assert "if (!fromRequirements)" not in auto_start_block
+    assert "if (!outlineGenerationStarted)" in auto_start_block

--- a/tests/test_project_workflow_regressions.py
+++ b/tests/test_project_workflow_regressions.py
@@ -285,6 +285,27 @@ def test_outline_operations_send_structure_operation_payload():
     assert "await saveSingleSlideToServer(" in script
 
 
+def test_ai_slide_edit_stream_displays_status_without_rendering_full_html():
+    script = _read(
+        "src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js"
+    )
+
+    assert "function sanitizeAIStreamSummary(text)" in script
+    assert r".replace(/```(?:html)?[\s\S]*?```/gi, ' ')" in script
+    assert r".replace(/<html[\s\S]*?<\/html>/gi, ' ')" in script
+    assert "renderAIStreamStatus(aiMessageDiv, fullResponse, 'streaming')" in script
+    assert "buildAIStreamStatusMessage(fullResponse, 'complete', !!newHtmlContent)" in script
+
+    assert "setAssistantMessageText(aiMessageDiv, fullResponse)" not in script
+    assert "updateAIChatHistoryMessage(streamingMessageId, fullResponse)" not in script
+    assert "newHtmlContent.substring(0, 200)" not in script
+    assert "fullResponse.substring(0, 500)" not in script
+
+    assert "addApplyChangesButton(aiMessageDiv, newHtmlContent)" in script
+    assert "await applyAIChanges(newHtmlContent)" in script
+    assert "showHTMLPreview(newHtmlContent)" in script
+
+
 def test_project_detail_outline_supports_drag_delete_and_duplicate():
     content = _read("src/landppt/web/templates/components/project/detail/content_1.html")
     script = _read("src/landppt/web/templates/components/project/detail/extra_js_1.html")

--- a/tests/test_sync_db_config_access.py
+++ b/tests/test_sync_db_config_access.py
@@ -71,11 +71,11 @@ def test_image_service_config_load_config_from_db_sync(monkeypatch):
     assert config.get_provider_config("searxng")["host"] == "https://searx.example.com"
 
 
-def test_pdf_to_pptx_converter_license_key_uses_sync_db_config(monkeypatch):
+def test_pdf_to_pptx_converter_license_key_uses_system_sync_db_config(monkeypatch):
     class FakeDBConfigService:
         def get_config_value_sync(self, key, user_id=None):
             assert key == "apryse_license_key"
-            assert user_id == 12
+            assert user_id is None
             return "sync-license-key"
 
     import landppt.services.db_config_service as db_mod
@@ -86,6 +86,24 @@ def test_pdf_to_pptx_converter_license_key_uses_sync_db_config(monkeypatch):
 
     assert converter.license_key == "sync-license-key"
     assert converter.license_key == "sync-license-key"
+
+
+def test_pdf_to_pptx_converter_uses_server_sdk_system_license_path():
+    root = __import__("pathlib").Path(__file__).resolve().parents[1]
+    converter_text = (root / "src/landppt/services/pdf_to_pptx_converter.py").read_text(encoding="utf-8")
+    export_route_text = (root / "src/landppt/web/route_modules/export_routes.py").read_text(encoding="utf-8")
+    template_text = (
+        root / "src/landppt/web/templates/pages/project/project_slides_editor.html"
+    ).read_text(encoding="utf-8")
+
+    assert "PDFNet.Initialize(self.license_key)" in converter_text
+    assert "get_all_config(user_id=None)" in converter_text
+    assert 'get_config_value_sync("apryse_license_key", user_id=None)' in converter_text
+    assert "get_all_config(user_id=self.user_id)" not in converter_text
+    assert 'get_config_value_sync("apryse_license_key", user_id=self.user_id)' not in converter_text
+    assert "Pre-load the system Apryse Server SDK license key" in export_route_text
+    assert "Pre-load user's license key" not in export_route_text
+    assert "apryse_license_key" not in template_text
 
 
 def test_database_config_service_get_config_value_sync(monkeypatch):

--- a/tests/test_web_route_modularization.py
+++ b/tests/test_web_route_modularization.py
@@ -402,6 +402,17 @@ def test_project_slides_editor_template_uses_extracted_assets():
     assert inline_script_marker not in template_text
 
 
+def test_project_slides_editor_standard_pptx_export_gate_is_route_backed():
+    route_text = _read("src/landppt/web/route_modules/project_workspace_routes.py")
+    template_text = _read("src/landppt/web/templates/pages/project/project_slides_editor.html")
+
+    assert "from .export_support import _is_standard_pptx_export_enabled" in route_text
+    assert "standard_pptx_export_enabled = await _is_standard_pptx_export_enabled()" in route_text
+    assert '"standard_pptx_export_enabled": standard_pptx_export_enabled' in route_text
+    assert "{% if standard_pptx_export_enabled %}" in template_text
+    assert "apryse_license_key" not in template_text
+
+
 def test_extracted_editor_assets_do_not_embed_template_syntax():
     for relative_path in [
         "src/landppt/web/static/css/pages/project/slides_editor/projectSlidesEditor.css",


### PR DESCRIPTION
## Summary
- make continue-from-stage return an explicit outline stream action so the browser actually resumes outline generation
- mark outline generation as running/failed across stream startup, provider errors, empty output, parse failures, and SSE error payloads
- load the Apryse Server SDK license from system config for PPTX export and pass the standard PPTX export gate into the editor route

## Tests
- `uv run pytest tests/test_project_workflow_regressions.py tests/test_sync_db_config_access.py::test_pdf_to_pptx_converter_license_key_uses_system_sync_db_config tests/test_sync_db_config_access.py::test_pdf_to_pptx_converter_uses_server_sdk_system_license_path tests/test_web_route_modularization.py::test_project_slides_editor_standard_pptx_export_gate_is_route_backed`

## Note
- `uv run pytest tests/test_project_workflow_regressions.py tests/test_sync_db_config_access.py tests/test_web_route_modularization.py` has one pre-existing failure on `test_admin_env_editor_surface_was_removed_but_db_config_routes_remain`: `admin_routes.py` already contains `EnvFileUpdateRequest` and `/api/system-env-file` routes on current `master`.