### PR TITLE
fix: emit outline before completing research stream

### DIFF
--- a/src/landppt/services/outline/project_outline_streaming_service.py
+++ b/src/landppt/services/outline/project_outline_streaming_service.py
@@ -398,6 +398,7 @@ class ProjectOutlineStreamingService:
                     except Exception as save_error:
                         logger.error(f'❌ Exception while saving research-enhanced outline: {str(save_error)}')
                     await self._update_outline_generation_stage(project_id, structured_outline)
+                    yield f"data: {json.dumps({'outline': structured_outline}, ensure_ascii=False)}\n\n"
                     yield f"data: {json.dumps({'done': True, 'llm_call_count': research_event.get('llm_call_count', 0)})}\n\n"
                     return
             page_count_settings = confirmed_requirements.get('page_count_settings', {})

--- a/tests/test_runtime_provider_and_outline_streaming.py
+++ b/tests/test_runtime_provider_and_outline_streaming.py
@@ -307,12 +307,16 @@ class _ProjectManagerStub:
         self.project = project
         self.projects = {}
         self.status_updates = []
+        self.stage_status_updates = []
 
     async def get_project(self, project_id):
         return self.project
 
     async def update_project_status(self, project_id, status):
         self.status_updates.append((project_id, status))
+
+    async def update_stage_status(self, project_id, stage_id, status, progress=None, result=None):
+        self.stage_status_updates.append((project_id, stage_id, status, progress, result))
 
 
 class _OutlineStreamingFreshGenerationStubService:
@@ -387,6 +391,7 @@ async def test_generate_outline_streaming_force_regenerate_skips_saved_outline(m
     assert stub.project_manager.status_updates == [("project-1", "in_progress")]
     assert stub.stage_updates
     assert project.outline["title"] == "fresh"
+    assert any('"outline"' in chunk and '"fresh"' in chunk for chunk in events)
     assert any('"done": true' in chunk for chunk in events)
 
 


### PR DESCRIPTION
## Summary
- emit the structured outline SSE event before marking research-enhanced outline generation as done
- keep the existing done event and stage update behavior intact
- add coverage to ensure fresh regenerated outlines are streamed to the frontend before completion

## Why
When the research-enhanced outline path finished, it saved the outline and emitted done without first sending the standard outline payload. The frontend relies on that outline event to render the generated outline and stop the loading state in the live SSE flow.

## Verification
- uv run python -m py_compile src\\landppt\\services\\outline\\project_outline_streaming_service.py
- uv run pytest tests/test_runtime_provider_and_outline_streaming.py::test_generate_outline_streaming_force_regenerate_skips_saved_outline tests/test_runtime_provider_and_outline_streaming.py::test_generate_outline_streaming_replays_saved_outline_without_regeneration
- uv run pytest tests/test_project_workflow_regressions.py

Also manually verified a new local research-mode project generated a 6-slide outline and the TODO page switched from the loading animation to the outline preview with the Start PPT button.