### PR TITLE
fix: project duplication failure and speech script notification mojibake

### DIFF
--- a/src/landppt/database/service.py
+++ b/src/landppt/database/service.py
@@ -957,11 +957,16 @@ class DatabaseService:
                     )
 
             for slide in sorted(source.slides, key=lambda item: item.slide_index):
+                # slide_id 列为 VARCHAR(100)。直接在原 id 后追加 "_copy_xxxxxxxx"
+                # 会在多次复制后不断变长并越界，导致 PostgreSQL
+                # StringDataRightTruncationError。改用基于编号的固定短 id，
+                # 长度恒定，不随复制次数增长。
+                new_slide_id = f"slide_{slide.slide_index}_{uuid.uuid4().hex[:8]}"
                 self.session.add(
                     DBSlideData(
                         project_id=new_project_id,
                         slide_index=slide.slide_index,
-                        slide_id=f"{slide.slide_id}_copy_{uuid.uuid4().hex[:8]}",
+                        slide_id=new_slide_id,
                         title=slide.title,
                         content_type=slide.content_type,
                         html_content=slide.html_content,

--- a/src/landppt/web/admin_routes.py
+++ b/src/landppt/web/admin_routes.py
@@ -1151,7 +1151,7 @@ async def export_redemption_codes(
 ):
     """Export redemption codes as CSV (filters match list endpoint)."""
     if not app_config.enable_credits_system:
-        raise HTTPException(status_code=400, detail="绉垎绯荤粺鏈惎鐢?")
+        raise HTTPException(status_code=400, detail="积分系统未启用")
 
     import csv
     import io

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.speechScriptsDialog.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.speechScriptsDialog.js
@@ -409,7 +409,7 @@
                         updateProgressToast(progressToast, progress.message, 100);
                         setTimeout(() => {
                             closeProgressToast(progressToast);
-                            showNotification('婕旇绋跨敓鎴愬畬鎴愶紒', 'success');
+                            showNotification('演讲稿生成完成！', 'success');
                             console.log('Starting to poll for speech scripts...');
                             pollForSpeechScripts();
                         }, 500);
@@ -418,7 +418,7 @@
 
                     if (progress.status === 'failed') {
                         closeProgressToast(progressToast);
-                        showNotification(`鐢熸垚澶辫触: ${progress.message}`, 'error');
+                        showNotification(`生成失败: ${progress.message}`, 'error');
                         return true;
                     }
 


### PR DESCRIPTION
## Changes

1. **`duplicate_project` (`database/service.py`)**: generate a bounded slide_id `slide_<index>_<hex>` instead of appending `_copy_xxxxxxxx` to the original id on each copy. Repeated copies made the id grow past `VARCHAR(100)`, causing a PostgreSQL `StringDataRightTruncationError` that surfaced misleadingly as a 404 "Project not found".
2. **Speech script dialog (`projectSlidesEditor.speechScriptsDialog.js`)**: fix garbled Chinese in the generation completion/failure notifications.
3. **`admin_routes.py`**: fix garbled Chinese in the redemption code export error message.

## Notes
- No data migration required; affected projects can be duplicated normally after rebuild.
- Front-end assets show correct text after a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)