### PR TITLE
fix: redesign PPT projector and exported HTML projection

### DIFF
--- a/src/landppt/web/route_modules/export_support.py
+++ b/src/landppt/web/route_modules/export_support.py
@@ -465,20 +465,26 @@ def _generate_html_export_sync(project) -> bytes:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
 
-        # Generate individual HTML files for each slide
+        total_slides = len(project.slides_data)
+
+        # Raw slide documents live in slides/ and are embedded by the viewers
+        raw_dir = temp_path / "slides"
+        raw_dir.mkdir()
+
         slide_files = []
         for i, slide in enumerate(project.slides_data):
             slide_filename = f"slide_{i+1}.html"
             slide_files.append(slide_filename)
 
-            # Create complete HTML document for each slide
-            slide_html = _generate_individual_slide_html_sync(slide, i+1, len(project.slides_data), project.topic)
+            raw_html = _wrap_raw_slide_html_sync(slide, project.topic)
+            with open(raw_dir / slide_filename, 'w', encoding='utf-8') as f:
+                f.write(raw_html)
 
-            slide_path = temp_path / slide_filename
-            with open(slide_path, 'w', encoding='utf-8') as f:
-                f.write(slide_html)
+            viewer_html = _generate_individual_slide_html_sync(slide, i+1, total_slides, project.topic)
+            with open(temp_path / slide_filename, 'w', encoding='utf-8') as f:
+                f.write(viewer_html)
 
-        # Generate index.html slideshow page
+        # Generate index.html projector page
         index_html = _generate_slideshow_index_sync(project, slide_files)
         index_path = temp_path / "index.html"
         with open(index_path, 'w', encoding='utf-8') as f:
@@ -492,173 +498,426 @@ def _generate_html_export_sync(project) -> bytes:
             # Add index.html
             zipf.write(index_path, "index.html")
 
-            # Add all slide files
+            # Add viewer and raw slide files
             for slide_file in slide_files:
-                slide_path = temp_path / slide_file
-                zipf.write(slide_path, slide_file)
+                zipf.write(temp_path / slide_file, slide_file)
+                zipf.write(raw_dir / slide_file, f"slides/{slide_file}")
 
         # Read ZIP file content
         with open(zip_path, 'rb') as f:
             return f.read()
 
 
-def _generate_individual_slide_html_sync(slide, slide_number: int, total_slides: int, topic: str) -> str:
-    """同步生成单个幻灯片HTML（在线程池中运行）"""
+def _wrap_raw_slide_html_sync(slide, topic: str) -> str:
+    """确保幻灯片内容是完整的HTML文档（1280x720画布）"""
+    import html as html_module
+
     slide_html = slide.get('html_content', '')
+    stripped = slide_html.strip().lower()
+    if stripped.startswith('<!doctype') or stripped.startswith('<html'):
+        return slide_html
+
+    return f"""<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>{html_module.escape(topic)}</title>
+    <style>
+        html, body {{
+            margin: 0;
+            padding: 0;
+            width: 1280px;
+            height: 720px;
+            overflow: hidden;
+            font-family: 'Microsoft YaHei', 'PingFang SC', sans-serif;
+            background: white;
+        }}
+    </style>
+</head>
+<body>
+{slide_html}
+</body>
+</html>"""
+
+
+# 投影缩放脚本：将1280x720的幻灯片iframe等比缩放至视口并居中
+_PROJECTOR_SCALE_JS = """
+        var BASE_W = 1280, BASE_H = 720;
+        var slideFrame = document.getElementById('slideFrame');
+        function applyScale() {
+            var w = window.innerWidth, h = window.innerHeight;
+            var s = Math.min(w / BASE_W, h / BASE_H);
+            slideFrame.style.left = ((w - BASE_W * s) / 2) + 'px';
+            slideFrame.style.top = ((h - BASE_H * s) / 2) + 'px';
+            slideFrame.style.transform = 'scale(' + s + ')';
+        }
+        window.addEventListener('resize', applyScale);
+        document.addEventListener('fullscreenchange', applyScale);
+        applyScale();
+
+        function toggleFullscreen() {
+            if (!document.fullscreenElement) {
+                document.documentElement.requestFullscreen().catch(function () {});
+            } else if (document.exitFullscreen) {
+                document.exitFullscreen();
+            }
+        }
+"""
+
+_PROJECTOR_STAGE_CSS = """
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html, body {
+            width: 100%;
+            height: 100%;
+            background: #000;
+            overflow: hidden;
+            font-family: 'Microsoft YaHei', 'PingFang SC', sans-serif;
+        }
+        .stage { position: fixed; inset: 0; }
+        .stage iframe {
+            position: absolute;
+            width: 1280px;
+            height: 720px;
+            border: none;
+            background: #fff;
+            transform-origin: top left;
+        }
+        /* 透明遮罩：捕获幻灯片区域的鼠标/键盘事件（iframe内的事件不会冒泡到父页面），
+           并支持点击翻页 */
+        .stage-shield { position: fixed; inset: 0; z-index: 50; }
+        body.ui-hidden .stage-shield { cursor: none; }
+        .ctrl-btn {
+            background: rgba(255,255,255,0.14);
+            color: #fff;
+            border: 1px solid rgba(255,255,255,0.25);
+            padding: 8px 16px;
+            border-radius: 20px;
+            cursor: pointer;
+            font-size: 14px;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            transition: background 0.2s;
+        }
+        .ctrl-btn:hover { background: rgba(255,255,255,0.3); color: #fff; }
+        .controls {
+            position: fixed;
+            bottom: 24px;
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            background: rgba(0,0,0,0.65);
+            border-radius: 30px;
+            padding: 10px 16px;
+            z-index: 100;
+            transition: opacity 0.3s;
+        }
+        .top-bar {
+            position: fixed;
+            top: 16px;
+            right: 16px;
+            display: flex;
+            gap: 10px;
+            z-index: 100;
+            transition: opacity 0.3s;
+        }
+        body.ui-hidden .controls,
+        body.ui-hidden .top-bar {
+            opacity: 0;
+            pointer-events: none;
+        }
+        .counter { color: #fff; font-size: 14px; min-width: 64px; text-align: center; }
+"""
+
+_UI_AUTO_HIDE_JS = """
+        var uiHideTimer = null;
+        function revealUi() {
+            document.body.classList.remove('ui-hidden');
+            if (uiHideTimer) clearTimeout(uiHideTimer);
+            uiHideTimer = setTimeout(function () {
+                document.body.classList.add('ui-hidden');
+            }, 2500);
+        }
+        document.addEventListener('mousemove', revealUi);
+        document.addEventListener('keydown', revealUi);
+        document.addEventListener('touchstart', revealUi, { passive: true });
+        revealUi();
+"""
+
+# 滚轮翻页：向下滚动下一页，向上滚动上一页。
+# 节流避免一次惯性滚动连翻多页；页面需先定义 wheelPrev()/wheelNext()。
+# 在.overview（目录）内滚动时不拦截，保持列表原生滚动。
+_WHEEL_NAV_JS = """
+        var wheelLockUntil = 0;
+        document.addEventListener('wheel', function (e) {
+            if (e.target.closest && e.target.closest('.overview')) return;
+            e.preventDefault();
+            var now = Date.now();
+            if (now < wheelLockUntil || Math.abs(e.deltaY) < 4) return;
+            wheelLockUntil = now + 350;
+            if (e.deltaY > 0) { wheelNext(); } else { wheelPrev(); }
+        }, { passive: false });
+"""
+
+
+def _generate_individual_slide_html_sync(slide, slide_number: int, total_slides: int, topic: str) -> str:
+    """同步生成单个幻灯片查看页（在线程池中运行）——iframe等比缩放投影"""
+    import html as html_module
+
     slide_title = slide.get('title', f'第{slide_number}页')
 
-    # Check if it's already a complete HTML document
-    import re
-    if slide_html.strip().lower().startswith('<!doctype') or slide_html.strip().lower().startswith('<html'):
-        # It's a complete HTML document, enhance it with navigation
-        return _enhance_complete_html_with_navigation(slide_html, slide_number, total_slides, topic, slide_title)
-    else:
-        # It's just content, wrap it in a complete structure
-        slide_content = slide_html
+    prev_btn = (
+        f'<a class="ctrl-btn" href="slide_{slide_number-1}.html">‹ 上一页</a>'
+        if slide_number > 1 else ''
+    )
+    next_btn = (
+        f'<a class="ctrl-btn" href="slide_{slide_number+1}.html">下一页 ›</a>'
+        if slide_number < total_slides else ''
+    )
 
     return f"""<!DOCTYPE html>
 <html lang="zh-CN">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{topic} - {slide_title}</title>
+    <title>{html_module.escape(topic)} - {html_module.escape(slide_title)}</title>
     <style>
-        body {{
-            margin: 0;
-            padding: 0;
-            font-family: 'Microsoft YaHei', 'PingFang SC', sans-serif;
-            background: #f5f5f5;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            min-height: 100vh;
-        }}
-        .slide-container {{
-            width: 90vw;
-            height: 90vh;
-            background: white;
-            border-radius: 10px;
-            box-shadow: 0 4px 20px rgba(0,0,0,0.1);
-            overflow: hidden;
-            position: relative;
-        }}
-        .slide-content {{
-            width: 100%;
-            height: 100%;
-            padding: 20px;
-            box-sizing: border-box;
-        }}
-        .slide-number {{
-            position: absolute;
-            bottom: 20px;
-            right: 20px;
-            background: rgba(0,0,0,0.7);
-            color: white;
-            padding: 5px 10px;
-            border-radius: 5px;
-            font-size: 14px;
-        }}
+{_PROJECTOR_STAGE_CSS}
     </style>
 </head>
 <body>
-    <div class="slide-container">
-        <div class="slide-content">
-            {slide_content}
-        </div>
-        <div class="slide-number">{slide_number} / {total_slides}</div>
+    <div class="stage">
+        <iframe id="slideFrame" src="slides/slide_{slide_number}.html" title="幻灯片 {slide_number}"></iframe>
     </div>
+    <div class="stage-shield" id="stageShield" title="点击翻到下一页"></div>
+    <div class="top-bar">
+        <button class="ctrl-btn" onclick="toggleFullscreen()" title="全屏 (F)">⛶ 全屏</button>
+    </div>
+    <div class="controls">
+        <a class="ctrl-btn" href="index.html">🏠 目录</a>
+        {prev_btn}
+        <span class="counter">{slide_number} / {total_slides}</span>
+        {next_btn}
+    </div>
+    <script>
+{_PROJECTOR_SCALE_JS}
+{_UI_AUTO_HIDE_JS}
+        document.addEventListener('keydown', function (e) {{
+            if (e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'PageUp') {{
+                if ({slide_number} > 1) window.location.href = 'slide_{slide_number-1}.html';
+            }} else if (e.key === 'ArrowRight' || e.key === 'ArrowDown' || e.key === 'PageDown' || e.key === ' ' || e.key === 'Enter') {{
+                if ({slide_number} < {total_slides}) window.location.href = 'slide_{slide_number+1}.html';
+            }} else if (e.key === 'Escape') {{
+                window.location.href = 'index.html';
+            }} else if (e.key === 'f' || e.key === 'F') {{
+                toggleFullscreen();
+            }}
+        }});
+        document.getElementById('stageShield').addEventListener('click', function () {{
+            if ({slide_number} < {total_slides}) window.location.href = 'slide_{slide_number+1}.html';
+        }});
+        function wheelPrev() {{
+            if ({slide_number} > 1) window.location.href = 'slide_{slide_number-1}.html';
+        }}
+        function wheelNext() {{
+            if ({slide_number} < {total_slides}) window.location.href = 'slide_{slide_number+1}.html';
+        }}
+{_WHEEL_NAV_JS}
+    </script>
 </body>
 </html>"""
 
 
 def _generate_slideshow_index_sync(project, slide_files: list) -> str:
-    """同步生成幻灯片索引页面（在线程池中运行）"""
-    slides_list = ""
-    for i, slide_file in enumerate(slide_files):
-        slide = project.slides_data[i]
-        slide_title = slide.get('title', f'第{i+1}页')
-        slides_list += f"""
-        <div class="slide-item" onclick="openSlide('{slide_file}')">
-            <div class="slide-preview">
-                <div class="slide-number">{i+1}</div>
-                <div class="slide-title">{slide_title}</div>
-            </div>
-        </div>"""
+    """同步生成放映页面（在线程池中运行）——全屏投影 + 目录浏览"""
+    import html as html_module
+    import json
+
+    total_slides = len(slide_files)
+    slide_titles = [
+        project.slides_data[i].get('title', f'第{i+1}页')
+        for i in range(total_slides)
+    ]
+    titles_json = json.dumps(slide_titles, ensure_ascii=False)
+    topic_escaped = html_module.escape(project.topic)
 
     return f"""<!DOCTYPE html>
 <html lang="zh-CN">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{project.topic} - PPT放映</title>
+    <title>{topic_escaped} - PPT放映</title>
     <style>
-        body {{
-            margin: 0;
-            padding: 0;
-            font-family: 'Microsoft YaHei', 'PingFang SC', sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
+{_PROJECTOR_STAGE_CSS}
+        .overview {{
+            position: fixed;
+            inset: 0;
+            background: rgba(10,10,20,0.96);
+            overflow-y: auto;
+            display: none;
+            z-index: 200;
+            padding: 40px;
         }}
-        .header {{
-            text-align: center;
-            padding: 40px 20px;
-            color: white;
-        }}
-        .header h1 {{
-            margin: 0;
-            font-size: 2.5em;
+        .overview.visible {{ display: block; }}
+        .overview h2 {{
+            color: #fff;
             font-weight: 300;
+            text-align: center;
+            margin-bottom: 30px;
         }}
-        .slides-grid {{
+        .overview-grid {{
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-            gap: 20px;
-            padding: 20px;
+            grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+            gap: 16px;
+            max-width: 1200px;
+            margin: 0 auto;
         }}
-        .slide-item {{
-            background: white;
+        .overview-item {{
+            background: #fff;
             border-radius: 10px;
-            padding: 20px;
+            padding: 18px;
             cursor: pointer;
-            transition: all 0.3s ease;
-            box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            transition: transform 0.2s, box-shadow 0.2s;
         }}
-        .slide-item:hover {{
-            transform: translateY(-5px);
-            box-shadow: 0 8px 25px rgba(0,0,0,0.2);
+        .overview-item:hover {{
+            transform: translateY(-4px);
+            box-shadow: 0 8px 25px rgba(0,0,0,0.4);
         }}
-        .slide-number {{
+        .overview-num {{
             background: #007bff;
             color: white;
-            width: 40px;
-            height: 40px;
+            width: 36px;
+            height: 36px;
             border-radius: 50%;
             display: flex;
             align-items: center;
             justify-content: center;
-            margin: 0 auto 15px auto;
             font-weight: bold;
+            flex-shrink: 0;
         }}
-        .slide-title {{
-            font-size: 1.1em;
+        .overview-title {{
             color: #333;
-            margin: 0;
-            text-align: center;
+            font-size: 15px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }}
     </style>
 </head>
 <body>
-    <div class="header">
-        <h1>{project.topic}</h1>
-        <p>PPT演示文稿 - 共{len(slide_files)}页</p>
+    <div class="stage">
+        <iframe id="slideFrame" src="slides/slide_1.html" title="幻灯片"></iframe>
     </div>
-    <div class="slides-grid">
-        {slides_list}
+    <div class="stage-shield" id="stageShield" title="点击翻到下一页"></div>
+    <div class="top-bar">
+        <button class="ctrl-btn" onclick="toggleOverview()" title="目录 (G)">☰ 目录</button>
+        <button class="ctrl-btn" onclick="toggleFullscreen()" title="全屏 (F)">⛶ 全屏</button>
+    </div>
+    <div class="controls">
+        <button class="ctrl-btn" onclick="prevSlide()">‹ 上一页</button>
+        <span class="counter" id="counter">1 / {total_slides}</span>
+        <button class="ctrl-btn" onclick="nextSlide()">下一页 ›</button>
+    </div>
+    <div class="overview" id="overview">
+        <h2>{topic_escaped}（共{total_slides}页）</h2>
+        <div class="overview-grid" id="overviewGrid"></div>
     </div>
     <script>
-        function openSlide(slideFile) {{
-            window.open(slideFile, '_blank');
+        var TOTAL = {total_slides};
+        var TITLES = {titles_json};
+        var current = 0;
+{_PROJECTOR_SCALE_JS}
+{_UI_AUTO_HIDE_JS}
+        function showSlide(i) {{
+            if (i < 0 || i >= TOTAL) return;
+            current = i;
+            slideFrame.src = 'slides/slide_' + (i + 1) + '.html';
+            document.getElementById('counter').textContent = (i + 1) + ' / ' + TOTAL;
         }}
+        function prevSlide() {{ showSlide(current - 1); }}
+        function nextSlide() {{ showSlide(current + 1); }}
+
+        document.getElementById('stageShield').addEventListener('click', nextSlide);
+
+        function wheelPrev() {{ prevSlide(); }}
+        function wheelNext() {{ nextSlide(); }}
+{_WHEEL_NAV_JS}
+
+        var overview = document.getElementById('overview');
+        function toggleOverview() {{
+            overview.classList.toggle('visible');
+        }}
+
+        var grid = document.getElementById('overviewGrid');
+        TITLES.forEach(function (title, i) {{
+            var item = document.createElement('div');
+            item.className = 'overview-item';
+            var num = document.createElement('div');
+            num.className = 'overview-num';
+            num.textContent = i + 1;
+            var label = document.createElement('div');
+            label.className = 'overview-title';
+            label.textContent = title;
+            item.appendChild(num);
+            item.appendChild(label);
+            item.addEventListener('click', function () {{
+                overview.classList.remove('visible');
+                showSlide(i);
+            }});
+            grid.appendChild(item);
+        }});
+
+        document.addEventListener('keydown', function (e) {{
+            if (overview.classList.contains('visible') && e.key === 'Escape') {{
+                overview.classList.remove('visible');
+                return;
+            }}
+            switch (e.key) {{
+                case 'ArrowLeft':
+                case 'ArrowUp':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'ArrowRight':
+                case 'ArrowDown':
+                case 'PageDown':
+                case ' ':
+                case 'Enter':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    showSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    showSlide(TOTAL - 1);
+                    break;
+                case 'f':
+                case 'F':
+                    e.preventDefault();
+                    toggleFullscreen();
+                    break;
+                case 'g':
+                case 'G':
+                    e.preventDefault();
+                    toggleOverview();
+                    break;
+                default:
+                    if (e.key >= '1' && e.key <= '9') {{
+                        var n = parseInt(e.key, 10) - 1;
+                        if (n < TOTAL) showSlide(n);
+                    }}
+            }}
+        }});
     </script>
 </body>
 </html>"""

--- a/src/landppt/web/static/css/pages/project/slides_editor/projectSlidesEditor.css
+++ b/src/landppt/web/static/css/pages/project/slides_editor/projectSlidesEditor.css
@@ -950,39 +950,23 @@ body::before {
     align-items: center;
     /* 硬件加速 */
     transform: translateZ(0);
-    padding: 20px;
-    box-sizing: border-box;
 }
 
 .slideshow-slide {
-    background: white;
-    border-radius: 10px;
-    box-shadow: 0 10px 30px rgba(255, 255, 255, 0.2);
+    background: transparent;
     overflow: hidden;
     position: relative;
-    /* 使用flex确保PPT居中且尺寸自适应 */
     width: 100%;
     height: 100%;
-    max-width: calc(100vh * 16/9 - 40px);
-    /* 基于高度计算最大宽度，保持16:9比例 */
-    max-height: calc(100vw * 9/16 - 40px);
-    /* 基于宽度计算最大高度，保持16:9比例 */
-    aspect-ratio: 16/9;
-    /* 强制保持16:9比例 */
     /* 硬件加速 */
     transform: translateZ(0);
     will-change: transform;
 }
 
 .slideshow-slide iframe {
-    width: 100%;
-    height: 100%;
     border: none;
     background: white;
-    /* 移除过渡效果，避免闪烁 */
-    transform-origin: center center;
     /* 硬件加速 */
-    transform: translateZ(0);
     will-change: opacity;
     /* 确保iframe始终可见 */
     opacity: 1;
@@ -999,8 +983,6 @@ body::before {
     position: absolute;
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
 }
 
 .slideshow-slide .iframe-container iframe.hidden {
@@ -1018,83 +1000,69 @@ body::before {
     display: none;
 }
 
+/* 透明遮罩：捕获iframe上方的鼠标事件（iframe内的事件不会冒泡到父页面），
+   并支持点击翻页 */
+.slideshow-shield {
+    position: absolute;
+    inset: 0;
+    z-index: 50;
+}
+
+.slideshow-overlay.ui-hidden .slideshow-shield {
+    cursor: none;
+}
+
 .slideshow-controls {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 0 20px;
+    gap: 10px;
+    background: rgba(0, 0, 0, 0.65);
+    border-radius: 30px;
+    padding: 10px 16px;
+    z-index: 100;
+    transition: opacity 0.3s;
+}
+
+.slideshow-topbar {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    display: flex;
+    gap: 10px;
+    z-index: 100;
+    transition: opacity 0.3s;
+}
+
+.slideshow-overlay.ui-hidden .slideshow-controls,
+.slideshow-overlay.ui-hidden .slideshow-topbar {
     opacity: 0;
-    transition: opacity 0.4s ease;
     pointer-events: none;
 }
 
-.slideshow-controls.visible {
-    opacity: 1;
-    pointer-events: auto;
-}
-
 .slideshow-btn {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.14);
     color: white;
-    border: 2px solid rgba(255, 255, 255, 0.3);
-    padding: 10px 20px;
-    border-radius: 25px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    padding: 8px 16px;
+    border-radius: 20px;
     cursor: pointer;
-    transition: all 0.3s ease;
-    font-size: 16px;
+    transition: background 0.2s;
+    font-size: 14px;
 }
 
 .slideshow-btn:hover {
     background: rgba(255, 255, 255, 0.3);
-    border-color: rgba(255, 255, 255, 0.5);
 }
 
 .slideshow-info {
-    position: absolute;
-    bottom: 30px;
-    left: 50%;
-    transform: translateX(-50%);
     color: white;
-    font-size: 18px;
-    font-weight: bold;
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.4s ease;
-}
-
-.slideshow-info.visible {
-    opacity: 1;
-}
-
-.slideshow-exit {
-    position: absolute;
-    top: 30px;
-    right: 30px;
-    background: rgba(255, 255, 255, 0.2);
-    color: white;
-    border: 2px solid rgba(255, 255, 255, 0.3);
-    padding: 10px 15px;
-    border-radius: 50%;
-    cursor: pointer;
-    font-size: 20px;
-    transition: all 0.4s ease;
-    opacity: 0;
-    pointer-events: none;
-}
-
-.slideshow-exit.visible {
-    opacity: 1;
-    pointer-events: auto;
-}
-
-.slideshow-exit:hover {
-    background: rgba(255, 255, 255, 0.3);
-    border-color: rgba(255, 255, 255, 0.5);
+    font-size: 14px;
+    min-width: 64px;
+    text-align: center;
 }
 
 /* 响应式设计 */

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectEditorShareExport.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectEditorShareExport.js
@@ -360,25 +360,46 @@ async function exportToPPTXAsImages() {
 }
 
 
-function downloadHTML() {
-    // 显示提示信息
-    showNotification('正在准备HTML文件包...', 'info');
+async function downloadHTML() {
+    showNotification('正在生成HTML文件包...', 'info');
 
-    // 创建下载链接
-    const downloadLink = document.createElement('a');
-    downloadLink.href = `/api/projects/${window.landpptEditorConfig.projectId}/export/html`;
-    downloadLink.download = '';
-    downloadLink.style.display = 'none';
+    try {
+        // 先取回文件再触发下载，保证提示顺序与实际一致
+        const response = await fetch(`/api/projects/${window.landpptEditorConfig.projectId}/export/html`);
+        if (!response.ok) {
+            let detail = `服务返回异常(${response.status})`;
+            try {
+                const data = await response.json();
+                if (data && data.detail) detail = data.detail;
+            } catch (e) { /* 非JSON响应 */ }
+            throw new Error(detail);
+        }
 
-    // 添加到页面并触发下载
-    document.body.appendChild(downloadLink);
-    downloadLink.click();
-    document.body.removeChild(downloadLink);
+        const blob = await response.blob();
 
-    // 延迟显示成功消息
-    setTimeout(() => {
-        showNotification('HTML文件包下载已开始', 'success');
-    }, 1000);
+        // 从Content-Disposition中解析文件名
+        let filename = 'PPT.zip';
+        const disposition = response.headers.get('content-disposition') || '';
+        const utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+        if (utf8Match) {
+            filename = decodeURIComponent(utf8Match[1]);
+        }
+
+        const url = URL.createObjectURL(blob);
+        const downloadLink = document.createElement('a');
+        downloadLink.href = url;
+        downloadLink.download = filename;
+        downloadLink.style.display = 'none';
+        document.body.appendChild(downloadLink);
+        downloadLink.click();
+        document.body.removeChild(downloadLink);
+        URL.revokeObjectURL(url);
+
+        showNotification('HTML文件包已生成，开始下载', 'success');
+    } catch (error) {
+        console.error('HTML export error:', error);
+        showNotification(`HTML导出失败: ${error.message || error}`, 'error');
+    }
 }
 
 function showNotification(message, type = 'info') {

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.slideshow.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.slideshow.js
@@ -92,6 +92,59 @@ let isTransitioning = false; // 防止快速切换时的重复操作
 let currentFrameIndex = 1; // 当前显示的iframe索引 (1 或 2)
 let nextFrameIndex = 2; // 下一个iframe索引 (1 或 2)
 
+// 幻灯片基准尺寸（与编辑器预览一致）
+const SLIDESHOW_BASE_WIDTH = 1280;
+const SLIDESHOW_BASE_HEIGHT = 720;
+
+// 将固定尺寸(1280x720)的幻灯片内容缩放至放映容器大小
+function applySlideshowFrameScale() {
+    const container = document.querySelector('#slideshowOverlay .iframe-container');
+    if (!container) return;
+
+    const rect = container.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+
+    const scale = Math.min(rect.width / SLIDESHOW_BASE_WIDTH, rect.height / SLIDESHOW_BASE_HEIGHT);
+    const left = (rect.width - SLIDESHOW_BASE_WIDTH * scale) / 2;
+    const top = (rect.height - SLIDESHOW_BASE_HEIGHT * scale) / 2;
+
+    [document.getElementById('slideshowFrame1'), document.getElementById('slideshowFrame2')].forEach(frame => {
+        if (!frame) return;
+        frame.style.width = `${SLIDESHOW_BASE_WIDTH}px`;
+        frame.style.height = `${SLIDESHOW_BASE_HEIGHT}px`;
+        frame.style.left = `${left}px`;
+        frame.style.top = `${top}px`;
+        frame.style.transformOrigin = 'top left';
+        frame.style.transform = `scale(${scale})`;
+    });
+}
+
+function scheduleSlideshowFrameScale() {
+    applySlideshowFrameScale();
+    requestAnimationFrame(applySlideshowFrameScale);
+}
+
+// 遮罩层点击翻页
+function handleSlideshowShieldClick() {
+    nextSlideshow();
+}
+
+// 滚轮翻页：向下滚动下一页，向上滚动上一页（节流避免一次惯性滚动连翻多页）
+let slideshowWheelLockUntil = 0;
+
+function handleSlideshowWheel(e) {
+    if (!isSlideshow) return;
+    e.preventDefault();
+    const now = Date.now();
+    if (now < slideshowWheelLockUntil || Math.abs(e.deltaY) < 4) return;
+    slideshowWheelLockUntil = now + 350;
+    if (e.deltaY > 0) {
+        nextSlideshow();
+    } else {
+        previousSlideshow();
+    }
+}
+
 function startSlideshow() {
     if (!slidesData || slidesData.length === 0) {
         showNotification('没有可用的幻灯片！', 'warning');
@@ -108,6 +161,7 @@ function startSlideshow() {
     const overlay = document.getElementById('slideshowOverlay');
     const frame1 = document.getElementById('slideshowFrame1');
     const frame2 = document.getElementById('slideshowFrame2');
+    const shield = document.getElementById('slideshowShield');
 
     // 初始化iframe状态
     frame1.classList.add('visible');
@@ -115,9 +169,17 @@ function startSlideshow() {
     frame2.classList.add('hidden');
     frame2.classList.remove('visible');
 
+    // 遮罩层点击翻页
+    if (shield) {
+        shield.addEventListener('click', handleSlideshowShieldClick);
+    }
+
     // 使用requestAnimationFrame优化显示
     requestAnimationFrame(() => {
         overlay.style.display = 'flex';
+
+        // 根据窗口大小缩放幻灯片内容
+        scheduleSlideshowFrameScale();
 
         // 预加载当前和下一张幻灯片
         preloadSlideshowSlides();
@@ -133,6 +195,13 @@ function startSlideshow() {
 
     // Add keyboard event listeners
     document.addEventListener('keydown', handleSlideshowKeyboard);
+
+    // 滚轮翻页（绑定在overlay上，遮罩层保证幻灯片区域的滚动也能捕获）
+    overlay.addEventListener('wheel', handleSlideshowWheel, { passive: false });
+
+    // Re-scale on window resize / fullscreen change
+    window.addEventListener('resize', scheduleSlideshowFrameScale);
+    document.addEventListener('fullscreenchange', scheduleSlideshowFrameScale);
 
     // Add touch gesture support
     initializeSlideshowTouchGestures();
@@ -165,6 +234,11 @@ function exitSlideshow() {
     const overlay = document.getElementById('slideshowOverlay');
     const frame1 = document.getElementById('slideshowFrame1');
     const frame2 = document.getElementById('slideshowFrame2');
+    const shield = document.getElementById('slideshowShield');
+
+    if (shield) {
+        shield.removeEventListener('click', handleSlideshowShieldClick);
+    }
 
     // 使用fade out效果
     overlay.style.opacity = '0';
@@ -181,6 +255,13 @@ function exitSlideshow() {
 
     // Remove keyboard event listeners
     document.removeEventListener('keydown', handleSlideshowKeyboard);
+
+    // Remove wheel listener
+    overlay.removeEventListener('wheel', handleSlideshowWheel);
+
+    // Remove resize/fullscreen listeners
+    window.removeEventListener('resize', scheduleSlideshowFrameScale);
+    document.removeEventListener('fullscreenchange', scheduleSlideshowFrameScale);
 
     // Remove touch gesture listeners
     removeSlideshowTouchGestures();

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.speechScriptsManage.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.speechScriptsManage.js
@@ -1149,57 +1149,40 @@ function closeSpeechScriptsDialog() {
             }
         }
 
-        // 放映模式鼠标控制功能
+        // 放映模式控件自动隐藏（与导出HTML版放映一致：ui-hidden方案）
         let mouseMoveTimeout;
-        let isMouseIdle = false;
-        let slideshowControls, slideshowExitBtn, slideshowOverlay;
+        let slideshowOverlay;
 
         function handleSlideshowMouseMove() {
-            // 显示控制按钮
             showSlideshowControls();
 
             // 清除之前的定时器
             clearTimeout(mouseMoveTimeout);
 
-            // 设置新的定时器，3秒后隐藏控制按钮
+            // 设置新的定时器，2.5秒后隐藏控制按钮
             mouseMoveTimeout = setTimeout(() => {
                 hideSlideshowControls();
-            }, 3000);
+            }, 2500);
         }
 
         function showSlideshowControls() {
-            if (slideshowControls) slideshowControls.classList.add('visible');
-            if (slideshowExitBtn) slideshowExitBtn.classList.add('visible');
-            const slideshowInfo = document.getElementById('slideshowInfo');
-            if (slideshowInfo) slideshowInfo.classList.add('visible');
-            isMouseIdle = false;
-            // 显示鼠标光标
-            if (slideshowOverlay) slideshowOverlay.style.cursor = 'default';
+            if (slideshowOverlay) slideshowOverlay.classList.remove('ui-hidden');
         }
 
         function hideSlideshowControls() {
-            if (slideshowControls) slideshowControls.classList.remove('visible');
-            if (slideshowExitBtn) slideshowExitBtn.classList.remove('visible');
-            const slideshowInfo = document.getElementById('slideshowInfo');
-            if (slideshowInfo) slideshowInfo.classList.remove('visible');
-            isMouseIdle = true;
-            // 隐藏鼠标光标
-            if (slideshowOverlay) slideshowOverlay.style.cursor = 'none';
+            if (slideshowOverlay) slideshowOverlay.classList.add('ui-hidden');
         }
 
         function initializeSlideshowMouseControls() {
             slideshowOverlay = document.getElementById('slideshowOverlay');
-            slideshowControls = document.querySelector('.slideshow-controls');
-            slideshowExitBtn = document.querySelector('.slideshow-exit');
 
-            // 初始状态：隐藏控制按钮
-            hideSlideshowControls();
-
-            // 鼠标移动事件
+            // 鼠标移动/按键均可唤出控件（遮罩层保证iframe区域的移动也能捕获）
             slideshowOverlay.addEventListener('mousemove', handleSlideshowMouseMove);
+            slideshowOverlay.addEventListener('touchstart', handleSlideshowMouseMove, { passive: true });
+            document.addEventListener('keydown', handleSlideshowMouseMove);
 
-            // 鼠标离开事件
-            slideshowOverlay.addEventListener('mouseleave', hideSlideshowControls);
+            // 初始显示控件，然后按定时器自动隐藏
+            handleSlideshowMouseMove();
         }
 
         function removeSlideshowMouseControls() {
@@ -1209,15 +1192,12 @@ function closeSpeechScriptsDialog() {
             // 移除事件监听器
             if (slideshowOverlay) {
                 slideshowOverlay.removeEventListener('mousemove', handleSlideshowMouseMove);
-                slideshowOverlay.removeEventListener('mouseleave', hideSlideshowControls);
-
-                // 恢复鼠标光标
-                slideshowOverlay.style.cursor = 'default';
+                slideshowOverlay.removeEventListener('touchstart', handleSlideshowMouseMove);
+                slideshowOverlay.classList.remove('ui-hidden');
             }
+            document.removeEventListener('keydown', handleSlideshowMouseMove);
 
             // 清理引用
-            slideshowControls = null;
-            slideshowExitBtn = null;
             slideshowOverlay = null;
         }
 

--- a/src/landppt/web/templates/pages/project/project_slides_editor.html
+++ b/src/landppt/web/templates/pages/project/project_slides_editor.html
@@ -403,20 +403,19 @@
                 </div>
             </div>
 
-            <div class="slideshow-controls">
-                <button class="slideshow-btn" onclick="previousSlideshow()" title="上一页 (←)">
-                    <i class="fas fa-chevron-left"></i> 上一页
-                </button>
-                <button class="slideshow-btn" onclick="nextSlideshow()" title="下一页 (→)">
-                    下一页 <i class="fas fa-chevron-right"></i>
-                </button>
+            <!-- 透明遮罩：捕获iframe上方的鼠标事件并支持点击翻页 -->
+            <div class="slideshow-shield" id="slideshowShield" title="点击翻到下一页"></div>
+
+            <div class="slideshow-topbar">
+                <button class="slideshow-btn" onclick="toggleSlideshowFullscreen()" title="全屏 (F)">⛶ 全屏</button>
+                <button class="slideshow-btn" onclick="exitSlideshow()" title="退出放映 (Esc)">✕ 退出</button>
             </div>
 
-            <div class="slideshow-info" id="slideshowInfo">1 / 1</div>
-
-            <button class="slideshow-exit" onclick="exitSlideshow()" title="退出放映">
-                <i class="fas fa-times"></i>
-            </button>
+            <div class="slideshow-controls">
+                <button class="slideshow-btn" onclick="previousSlideshow()" title="上一页 (←)">‹ 上一页</button>
+                <span class="slideshow-info" id="slideshowInfo">1 / 1</span>
+                <button class="slideshow-btn" onclick="nextSlideshow()" title="下一页 (→)">下一页 ›</button>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
### Editor slideshow
  - Scale the 1280×720 slide content with \`transform: scale()\` to fit and center it on screen (same approach as \`/projects/{id}/fullscreen\`), re-scaling on window resize and fullscreen change
  - UI now matches the exported HTML projector: black stage, bottom pill controls (prev / counter / next), top-right fullscreen and exit buttons, 2.5s auto-hide

  ### Exported HTML package (download HTML)
  - Redesigned as a projector: raw slide documents go into \`slides/\`, while \`index.html\` and each \`slide_N.html\` embed them in a viewport-scaled iframe
  - \`index.html\` opens directly into a fullscreen slideshow of slide 1, with navigation controls, a table-of-contents overlay (☰ / G), fullscreen (F), keyboard shortcuts, and number-key jumps
  - Topic and slide titles are HTML-escaped; navigation is no longer regex-injected into the slide document itself, so slide CSS can't clash with the viewer chrome

  ### Floating toolbar could never be revealed again after auto-hide
  - Cause: mouse movement happens inside the slide iframe, and iframe events don't bubble to the parent page
  - Added a transparent shield layer over the slide area to capture mouse events; moving the mouse or pressing a key reveals the controls again, and clicking the slide advances to the next page