### PR TITLE
Add slide edit agent workflow and HTML export fixes

### DIFF
--- a/docs/superpowers/specs/2026-07-05-slide-edit-agent-design.md
+++ b/docs/superpowers/specs/2026-07-05-slide-edit-agent-design.md
@@ -1,0 +1,352 @@
+# Slide Edit Agent Design
+
+Date: 2026-07-05
+
+## Goal
+
+Convert the current sidebar AI editing assistant from a single-turn "generate HTML and apply" flow into an agent-style PPT editing assistant. The assistant should be able to reason over the current project, choose editing tools, produce validated slide changes, show its progress in the sidebar, and let the user confirm before changes are persisted.
+
+The first implementation should prioritize safe, observable editing of existing slides over broad autonomous behavior.
+
+## Current State
+
+The current sidebar flow is split across these areas:
+
+- `src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiChat.js`
+  - Sends current slide context to `/api/ai/slide-edit/stream`.
+  - Renders streamed assistant text.
+  - Extracts returned HTML and adds a manual "apply changes" button.
+- `src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js`
+  - Applies full-slide HTML into local `slidesData`, iframe preview, thumbnails, code editor, and server save.
+- `src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.quickAi.js`
+  - Edits a selected element through `/api/ai/element-edit`.
+  - Applies returned element HTML directly into the iframe DOM and saves the slide.
+- `src/landppt/web/route_modules/ai_edit_routes.py`
+  - Contains `/api/ai/slide-edit`, `/api/ai/slide-edit/stream`, `/api/ai/element-edit`, and related AI routes.
+- `src/landppt/web/route_modules/slide_routes.py`
+  - Contains `/api/projects/{project_id}/slides/{slide_index}/save`, the existing single-slide persistence path.
+
+The existing behavior has three limits:
+
+1. The model returns free-form text and possibly full HTML; the application then tries to extract a code block.
+2. There is no planning or tool observation loop, so multi-step requests are fragile.
+3. Validation and persistence are not separated from generation clearly enough for safe autonomous editing.
+
+The project already has a ReAct-style pattern in `src/landppt/services/deep_research_service.py`. The edit agent should reuse that pattern conceptually: structured actions, bounded iterations, tool observations, and stream events.
+
+## Recommended Approach
+
+Use a server-side agent loop with explicit PPT editing tools and a user-confirmed apply step.
+
+The agent may inspect slides, select elements, draft HTML changes, run validation, and emit a proposed patch. It must not persist the patch during the reasoning loop. Persistence happens only when the user confirms the proposal from the sidebar.
+
+This gives the product an agentic workflow while preserving editor safety and existing save semantics.
+
+## Non-Goals
+
+- Do not replace the whole slides editor.
+- Do not make the first version fully autonomous by default.
+- Do not build a new database persistence path for edited slides.
+- Do not require browser DOM access from the backend.
+- Do not remove the existing quick edit toolbar or manual HTML/code editor flows.
+
+## User Experience
+
+The sidebar remains the primary entry point. The user enters an editing instruction such as "make this slide more visual and simplify the text".
+
+The sidebar then shows a task timeline instead of only token text:
+
+1. Analyzing current slide and outline.
+2. Selecting relevant edit tools.
+3. Drafting changes.
+4. Validating HTML and layout constraints.
+5. Ready to preview.
+
+When the agent emits a draft, the user sees these actions:
+
+- Preview
+- Apply
+- Continue editing
+- Discard
+
+Default behavior is confirmation before applying. A later settings-controlled "auto-apply simple edits" mode can be added after the first version is stable.
+
+## Backend Architecture
+
+Add a new service:
+
+`src/landppt/services/slide/slide_edit_agent_service.py`
+
+Responsibilities:
+
+- Build compact editing context from project, slide, outline, selected element, uploaded images, and optional screenshots.
+- Run a bounded ReAct-style loop.
+- Parse model actions into structured tool calls.
+- Execute only registered editing tools.
+- Maintain a transcript of thought/action/observation summaries.
+- Produce a final draft with changed slide HTML, summary, validation result, and a stable proposal id.
+
+Suggested models:
+
+- `SlideEditAgentRequest`
+- `SlideEditAgentContext`
+- `SlideEditAction`
+- `SlideEditToolResult`
+- `SlideEditProposal`
+- `SlideEditValidationResult`
+
+The agent should use the existing editor or vision role provider:
+
+- Use `vision_analysis` when visual input is included.
+- Use `editor` otherwise.
+
+## Backend Routes
+
+Add these routes to `src/landppt/web/route_modules/ai_edit_routes.py` or a new imported module if the file grows too much:
+
+### `POST /api/ai/slide-edit-agent/stream`
+
+Runs the agent loop and streams events.
+
+Request fields:
+
+- `projectId`
+- `slideIndex`
+- `userRequest`
+- `chatHistory`
+- `mode`: `slide` or `element`
+- `selectedElementHtml`
+- `selectedElementId`
+- `slideScreenshot`
+- `elementScreenshot`
+- `images`
+- `maxIterations`
+
+Response is Server-Sent Events.
+
+Event types:
+
+- `agent_start`
+- `agent_step`
+- `tool_call`
+- `tool_result`
+- `draft_ready`
+- `validation_result`
+- `needs_confirmation`
+- `error`
+
+### `POST /api/ai/slide-edit-agent/apply`
+
+Persists an approved proposal.
+
+Request fields:
+
+- `proposalId`
+- `projectId`
+- `slideIndex`
+- `expectedBaseHash`
+- `htmlContent`
+- `slideData`
+
+The route must verify project ownership, verify that the current slide still matches `expectedBaseHash`, and then reuse the existing single-slide save path or the same `DatabaseProjectManager.save_single_slide()` behavior.
+
+### `POST /api/ai/slide-edit-agent/cancel`
+
+Cancels a running agent task if the implementation stores active jobs. If the first implementation runs per request without background task state, this route can return success for UI consistency and be wired to abort the browser request.
+
+## Tool Function Design
+
+The first version should expose a small, deterministic tool set.
+
+Read tools:
+
+- `get_project_context`
+  - Returns title, topic, scenario, slide count, and current outline metadata.
+- `get_slide`
+  - Returns one slide's title, type, content points, metadata, and HTML.
+- `list_slides`
+  - Returns compact slide summaries for cross-slide requests.
+- `inspect_slide_html`
+  - Returns a structural summary of headings, text blocks, images, tables, and candidate elements.
+- `select_elements`
+  - Finds likely target elements by text, tag, role, alt text, or agent-assigned id.
+
+Draft tools:
+
+- `replace_slide_html`
+  - Produces a new full-slide HTML draft.
+- `replace_element_html`
+  - Produces a draft where one selected element is replaced.
+- `update_text`
+  - Rewrites text content for one or more selected elements.
+- `update_style`
+  - Applies whitelisted CSS properties to selected elements.
+- `insert_element`
+  - Inserts an HTML element at a controlled location.
+- `delete_element`
+  - Removes selected elements from the draft.
+- `generate_image_for_slide`
+  - Calls existing image generation services and returns an image asset reference.
+- `auto_repair_layout`
+  - Uses the existing auto layout repair workflow for one slide.
+
+Validation and persistence tools:
+
+- `validate_slide_html`
+  - Rejects scripts, inline event handlers, invalid slide dimensions, missing root content, and obvious unsafe URLs.
+- `preview_patch`
+  - Returns before/after summary, changed element count, and optional compact diff.
+- `save_slide`
+  - Only available in the apply route, not inside the reasoning loop.
+
+All write-like tools in the agent loop operate on an in-memory draft. They return observations and updated draft state, not persisted database writes.
+
+## Agent Loop
+
+Default maximum iterations: 6.
+
+Allowed range: 2 to 12 for editing. This is intentionally lower than research because each edit loop carries large HTML context.
+
+Each model response should be parsed as JSON:
+
+```json
+{
+  "thought": "short reason for next action",
+  "action": "inspect_slide_html",
+  "action_input": {
+    "slide_index": 1
+  }
+}
+```
+
+Final response:
+
+```json
+{
+  "thought": "why the draft is ready",
+  "action": "final",
+  "action_input": {
+    "summary": "what changed",
+    "changed_slide_indices": [1],
+    "requires_confirmation": true
+  }
+}
+```
+
+The final proposal should include:
+
+- `proposalId`
+- `baseHash`
+- `summary`
+- `changedSlides`
+- `htmlContent`
+- `validation`
+- `toolTranscript`
+
+## Frontend Changes
+
+Update `projectSlidesEditor.aiChat.js`:
+
+- Send requests to `/api/ai/slide-edit-agent/stream`.
+- Parse structured SSE events.
+- Render timeline cards for agent steps and tools.
+- Render draft controls when `draft_ready` arrives.
+- Keep existing chat history storage, but store agent summaries rather than raw hidden tool JSON.
+
+Update `projectSlidesEditor.aiApply.js`:
+
+- Add `applyAgentProposal(proposal)` that calls `/api/ai/slide-edit-agent/apply`.
+- Reuse the existing local update logic from `applyAIChanges()` after the backend accepts the proposal.
+- Save undo state before applying.
+
+Update `projectSlidesEditor.quickAi.js`:
+
+- Keep the current popover UI.
+- Route element edits to the same agent endpoint with `mode: "element"`.
+- Send `selectedElementHtml`, `selectedElementId`, and optional element screenshot.
+- Apply returned element proposal through the same proposal/apply flow.
+
+Update the sidebar template in `project_slides_editor.html`:
+
+- Keep the existing title and input area.
+- Add a timeline container inside `#aiChatMessages`.
+- Keep upload, vision, free-dialog, and clear-context buttons.
+
+## Safety Rules
+
+- The agent loop cannot persist changes.
+- The apply route must verify project ownership through the current authenticated user.
+- The apply route must verify `expectedBaseHash` to avoid overwriting newer user edits.
+- HTML validation removes or rejects:
+  - `<script>` tags
+  - inline event handler attributes
+  - `javascript:` URLs
+  - malformed empty HTML
+- Element edits must preserve the selected element id while drafting, then strip temporary agent ids before final save.
+- If validation fails, the sidebar should show the error and offer "continue editing" rather than "apply".
+
+## Credits
+
+Charge one `ai_edit` operation per completed agent run that reaches `draft_ready` or a final answer. Do not charge per internal tool call in the first version. If image generation is invoked, keep existing image operation billing rules.
+
+## Persistence
+
+The final save must reuse the existing single-slide persistence behavior:
+
+- frontend local state update
+- iframe preview update
+- thumbnail update
+- code editor update
+- `/api/projects/{project_id}/slides/{slide_index}/save`
+- `DatabaseProjectManager.save_single_slide()`
+
+The agent apply route can either call the same internal save logic directly or return an accepted proposal that the frontend saves through `saveSingleSlideToServer()`. The safer first implementation is backend apply plus frontend local sync, because the backend can enforce `baseHash` before writing.
+
+## Testing Plan
+
+Backend tests:
+
+- Agent loop executes model-selected tools in order.
+- Unsupported tool names produce tool error observations.
+- Max iteration limit stops the loop predictably.
+- Draft tools do not call database persistence.
+- Apply route rejects mismatched `baseHash`.
+- Apply route saves only the requested slide.
+- HTML validator rejects scripts and inline event handlers.
+- Element mode preserves and then strips temporary element ids.
+
+Frontend/manual checks:
+
+- Sidebar shows agent step events.
+- Draft can be previewed before applying.
+- Applying updates preview, thumbnail, code editor, and saved slide.
+- Discard leaves current slide unchanged.
+- Element AI popover can edit a selected text block.
+- Vision mode still attaches screenshots.
+
+## Rollout Plan
+
+Phase 1:
+
+- Add backend service, schemas, tools, and tests.
+- Add stream route and apply route.
+- Keep existing `/api/ai/slide-edit/stream` untouched as fallback.
+
+Phase 2:
+
+- Wire sidebar to the agent endpoint.
+- Render timeline events and proposal controls.
+- Keep old HTML extraction apply button behind a fallback path.
+
+Phase 3:
+
+- Route quick element AI through the agent.
+- Add optional "continue editing this draft" loop.
+- Add settings for max iterations and simple-edit auto-apply only after validation is reliable.
+
+## Success Criteria
+
+- A user can ask for a multi-step edit and see the assistant inspect, modify, validate, preview, and apply the result.
+- Agent changes are not persisted until the user confirms.
+- Existing manual editing, quick editing, image upload, and vision mode continue to work.
+- Tests cover the agent loop, tool dispatch, validation, and save boundary.

--- a/src/landppt/services/slide/slide_edit_agent_service.py
+++ b/src/landppt/services/slide/slide_edit_agent_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import time
+import uuid
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional
@@ -295,6 +297,402 @@ def validate_slide_html(html: str) -> SlideEditValidationResult:
         warnings=warnings,
         sanitized_html=sanitized,
     )
+
+
+@dataclass
+class SlideEditAgentContext:
+    request: SlideEditAgentRequest
+    project_id: str
+    slide_index: int
+    mode: AgentEditMode
+    base_html: str
+    base_hash: str
+    slide_data: Dict[str, Any]
+    project_info: Dict[str, Any]
+    slide_outline: Dict[str, Any]
+    selected_element_id: Optional[str] = None
+    selected_element_html: Optional[str] = None
+
+    @classmethod
+    def from_request(cls, request: SlideEditAgentRequest) -> "SlideEditAgentContext":
+        base_html = request.slideContent or ""
+        slide_data = {
+            "page_number": request.slideIndex,
+            "title": request.slideTitle
+            or (request.slideOutline or {}).get("title")
+            or f"Slide {request.slideIndex}",
+            "html_content": base_html,
+            "slide_type": (request.slideOutline or {}).get("slide_type")
+            or (request.slideOutline or {}).get("type")
+            or "content",
+            "content_points": (request.slideOutline or {}).get("content_points") or [],
+            "metadata": {},
+            "is_user_edited": True,
+        }
+        return cls(
+            request=request,
+            project_id=request.projectId,
+            slide_index=request.slideIndex,
+            mode=request.mode,
+            base_html=base_html,
+            base_hash=compute_slide_html_hash(base_html),
+            slide_data=slide_data,
+            project_info=request.projectInfo or {},
+            slide_outline=request.slideOutline or {},
+            selected_element_id=request.selectedElementId,
+            selected_element_html=request.selectedElementHtml,
+        )
+
+
+class SlideEditToolRunner:
+    _STYLE_WHITELIST = {
+        "background",
+        "background-color",
+        "border",
+        "border-radius",
+        "box-shadow",
+        "color",
+        "display",
+        "font-family",
+        "font-size",
+        "font-weight",
+        "height",
+        "left",
+        "line-height",
+        "margin",
+        "margin-bottom",
+        "margin-left",
+        "margin-right",
+        "margin-top",
+        "max-height",
+        "max-width",
+        "min-height",
+        "min-width",
+        "opacity",
+        "padding",
+        "padding-bottom",
+        "padding-left",
+        "padding-right",
+        "padding-top",
+        "text-align",
+        "top",
+        "transform",
+        "width",
+        "z-index",
+    }
+
+    def __init__(self, context: SlideEditAgentContext):
+        self.context = context
+        self.current_html = context.base_html
+        self.transcript: List[Dict[str, Any]] = []
+
+    def available_tool_names(self) -> List[str]:
+        return [
+            "get_project_context",
+            "get_slide",
+            "list_slides",
+            "inspect_slide_html",
+            "select_elements",
+            "replace_slide_html",
+            "replace_element_html",
+            "update_text",
+            "update_style",
+            "insert_element",
+            "delete_element",
+            "validate_slide_html",
+            "preview_patch",
+        ]
+
+    async def execute_tool(self, tool_name: str, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = (tool_name or "").strip().lower().replace("-", "_")
+        data = tool_input if isinstance(tool_input, dict) else {"value": tool_input}
+
+        handlers = {
+            "get_project_context": self._tool_get_project_context,
+            "get_slide": self._tool_get_slide,
+            "list_slides": self._tool_list_slides,
+            "inspect_slide_html": self._tool_inspect_slide_html,
+            "select_elements": self._tool_select_elements,
+            "replace_slide_html": self._tool_replace_slide_html,
+            "replace_element_html": self._tool_replace_element_html,
+            "update_text": self._tool_update_text,
+            "update_style": self._tool_update_style,
+            "insert_element": self._tool_insert_element,
+            "delete_element": self._tool_delete_element,
+            "validate_slide_html": self._tool_validate_slide_html,
+            "preview_patch": self._tool_preview_patch,
+        }
+        handler = handlers.get(normalized)
+        if not handler:
+            return {
+                "success": False,
+                "tool": normalized,
+                "error": f"Unsupported slide edit tool: {normalized}",
+                "available_tools": self.available_tool_names(),
+            }
+
+        result = handler(data)
+        self.transcript.append(
+            {
+                "tool": normalized,
+                "input": data,
+                "success": bool(result.get("success")),
+                "summary": result.get("summary") or result.get("error") or "",
+            }
+        )
+        return result
+
+    def _soup(self) -> BeautifulSoup:
+        return BeautifulSoup(self.current_html or "", "html.parser")
+
+    def _set_html_from_soup(self, soup: BeautifulSoup) -> None:
+        self.current_html = str(soup).strip()
+
+    def _tool_get_project_context(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "success": True,
+            "tool": "get_project_context",
+            "project": self.context.project_info,
+            "slide_index": self.context.slide_index,
+            "mode": self.context.mode,
+            "outline": self.context.slide_outline,
+            "summary": "Loaded project and outline context.",
+        }
+
+    def _tool_get_slide(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "success": True,
+            "tool": "get_slide",
+            "slide": {**self.context.slide_data, "html_content": self.current_html},
+            "base_hash": self.context.base_hash,
+            "summary": f"Loaded slide {self.context.slide_index}.",
+        }
+
+    def _tool_list_slides(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "success": True,
+            "tool": "list_slides",
+            "slides": [
+                {
+                    "slide_index": self.context.slide_index,
+                    "title": self.context.slide_data.get("title"),
+                    "slide_type": self.context.slide_data.get("slide_type"),
+                }
+            ],
+            "summary": "Listed available slide summaries.",
+        }
+
+    def _tool_inspect_slide_html(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        soup = self._soup()
+        headings = [
+            {"selector": tag.name, "text": tag.get_text(" ", strip=True)}
+            for tag in soup.find_all(["h1", "h2", "h3"])[:10]
+        ]
+        text_blocks = [
+            {"selector": tag.name, "text": tag.get_text(" ", strip=True)[:300]}
+            for tag in soup.find_all(["p", "li", "span", "div"])[:20]
+            if tag.get_text(" ", strip=True)
+        ]
+        images = [
+            {"src": img.get("src", ""), "alt": img.get("alt", "")}
+            for img in soup.find_all("img")[:20]
+        ]
+        return {
+            "success": True,
+            "tool": "inspect_slide_html",
+            "headings": headings,
+            "text_blocks": text_blocks,
+            "images": images,
+            "summary": f"Found {len(headings)} headings, {len(text_blocks)} text blocks, and {len(images)} images.",
+        }
+
+    def _tool_select_elements(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        selector = str(tool_input.get("selector") or "").strip()
+        text = str(tool_input.get("text") or "").strip().lower()
+        soup = self._soup()
+        matches = []
+        candidates = soup.select(selector) if selector else soup.find_all(True)
+        for idx, node in enumerate(candidates[:100], start=1):
+            node_text = node.get_text(" ", strip=True)
+            if text and text not in node_text.lower():
+                continue
+            agent_id = node.get("data-agent-id") or f"agent-el-{idx}"
+            node["data-agent-id"] = agent_id
+            matches.append({"agent_id": agent_id, "tag": node.name, "text": node_text[:200]})
+        self._set_html_from_soup(soup)
+        return {
+            "success": True,
+            "tool": "select_elements",
+            "matches": matches,
+            "summary": f"Selected {len(matches)} elements.",
+        }
+
+    def _resolve_one(self, soup: BeautifulSoup, tool_input: Dict[str, Any]):
+        selector = str(tool_input.get("selector") or "").strip()
+        element_id = str(
+            tool_input.get("element_id") or self.context.selected_element_id or ""
+        ).strip()
+        if element_id:
+            found = soup.select_one(f'[data-agent-id="{element_id}"]') or soup.select_one(
+                f'[data-quick-ai-id="{element_id}"]'
+            )
+            if found:
+                return found
+        if selector:
+            return soup.select_one(selector)
+        return soup.find(True)
+
+    def _tool_replace_slide_html(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        html = str(tool_input.get("html") or tool_input.get("value") or "").strip()
+        validation = validate_slide_html(html)
+        if not validation.sanitized_html:
+            return {
+                "success": False,
+                "tool": "replace_slide_html",
+                "error": "replacement html is empty",
+            }
+        self.current_html = validation.sanitized_html
+        return {
+            "success": validation.valid,
+            "tool": "replace_slide_html",
+            "errors": validation.errors,
+            "summary": "Replaced full slide draft HTML.",
+        }
+
+    def _tool_replace_element_html(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        soup = self._soup()
+        target = self._resolve_one(soup, tool_input)
+        if not target:
+            return {
+                "success": False,
+                "tool": "replace_element_html",
+                "error": "target element not found",
+            }
+        fragment = BeautifulSoup(str(tool_input.get("html") or ""), "html.parser")
+        replacement = fragment.find(True)
+        if not replacement:
+            return {
+                "success": False,
+                "tool": "replace_element_html",
+                "error": "replacement element html is empty",
+            }
+        element_id = str(
+            tool_input.get("element_id") or self.context.selected_element_id or ""
+        ).strip()
+        if element_id:
+            replacement["data-quick-ai-id"] = element_id
+        target.replace_with(replacement)
+        self._set_html_from_soup(soup)
+        return {
+            "success": True,
+            "tool": "replace_element_html",
+            "summary": "Replaced selected element draft HTML.",
+        }
+
+    def _tool_update_text(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        soup = self._soup()
+        target = self._resolve_one(soup, tool_input)
+        if not target:
+            return {"success": False, "tool": "update_text", "error": "target element not found"}
+        target.clear()
+        target.append(str(tool_input.get("text") or ""))
+        self._set_html_from_soup(soup)
+        return {"success": True, "tool": "update_text", "summary": "Updated element text."}
+
+    def _tool_update_style(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        soup = self._soup()
+        target = self._resolve_one(soup, tool_input)
+        if not target:
+            return {
+                "success": False,
+                "tool": "update_style",
+                "error": "target element not found",
+            }
+        styles = tool_input.get("styles") if isinstance(tool_input.get("styles"), dict) else {}
+        current_style = target.get("style", "")
+        style_map: Dict[str, str] = {}
+        for item in current_style.split(";"):
+            if ":" in item:
+                key, value = item.split(":", 1)
+                style_map[key.strip().lower()] = value.strip()
+        for key, value in styles.items():
+            css_key = str(key).strip().lower()
+            css_value = str(value).strip()
+            if css_key in self._STYLE_WHITELIST and css_value and "url(" not in css_value.lower():
+                style_map[css_key] = css_value
+        target["style"] = "; ".join(f"{key}: {value}" for key, value in style_map.items())
+        self._set_html_from_soup(soup)
+        return {
+            "success": True,
+            "tool": "update_style",
+            "summary": "Updated whitelisted element styles.",
+        }
+
+    def _tool_insert_element(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        soup = self._soup()
+        parent = self._resolve_one(soup, {"selector": tool_input.get("parent_selector") or "body"})
+        fragment = BeautifulSoup(str(tool_input.get("html") or ""), "html.parser")
+        node = fragment.find(True)
+        if not parent or not node:
+            return {
+                "success": False,
+                "tool": "insert_element",
+                "error": "parent or inserted element not found",
+            }
+        parent.append(node)
+        self._set_html_from_soup(soup)
+        return {"success": True, "tool": "insert_element", "summary": "Inserted element into draft."}
+
+    def _tool_delete_element(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        soup = self._soup()
+        target = self._resolve_one(soup, tool_input)
+        if not target:
+            return {"success": False, "tool": "delete_element", "error": "target element not found"}
+        target.decompose()
+        self._set_html_from_soup(soup)
+        return {"success": True, "tool": "delete_element", "summary": "Deleted element from draft."}
+
+    def _tool_validate_slide_html(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        validation = validate_slide_html(self.current_html)
+        return {
+            "success": validation.valid,
+            "tool": "validate_slide_html",
+            "errors": validation.errors,
+            "warnings": validation.warnings,
+            "summary": "Validated draft HTML.",
+        }
+
+    def _tool_preview_patch(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "success": True,
+            "tool": "preview_patch",
+            "base_hash": self.context.base_hash,
+            "new_hash": compute_slide_html_hash(self.current_html),
+            "changed": compute_slide_html_hash(self.current_html) != self.context.base_hash,
+            "summary": "Prepared before/after patch preview.",
+        }
+
+    def build_proposal(
+        self, summary: str, changed_slide_indices: Optional[List[int]] = None
+    ) -> SlideEditProposal:
+        cleaned_html = strip_agent_ids(self.current_html)
+        validation = validate_slide_html(cleaned_html)
+        slide_data = {
+            **self.context.slide_data,
+            "html_content": validation.sanitized_html,
+            "is_user_edited": True,
+        }
+        return SlideEditProposal(
+            proposal_id=f"slide-edit-{uuid.uuid4().hex}",
+            base_hash=self.context.base_hash,
+            summary=summary or "Prepared slide edit proposal.",
+            changed_slide_indices=changed_slide_indices or [self.context.slide_index],
+            html_content=validation.sanitized_html,
+            validation=validation,
+            tool_transcript=list(self.transcript),
+            slide_data=slide_data,
+            created_at=time.time(),
+        )
 
 
 EventEmitter = Callable[[Dict[str, Any]], Awaitable[None]]

--- a/src/landppt/services/slide/slide_edit_agent_service.py
+++ b/src/landppt/services/slide/slide_edit_agent_service.py
@@ -582,7 +582,11 @@ class SlideEditToolRunner:
                 return soup.select_one(selector), None
             except Exception as exc:
                 return None, self._invalid_selector_error(tool_name, selector, exc)
-        return soup.find(True), None
+        return None, {
+            "success": False,
+            "tool": tool_name,
+            "error": "target element requires element_id, selected element id, or selector",
+        }
 
     def _tool_replace_slide_html(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
         html = str(tool_input.get("html") or tool_input.get("value") or "").strip()

--- a/src/landppt/services/slide/slide_edit_agent_service.py
+++ b/src/landppt/services/slide/slide_edit_agent_service.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional
+
+from bs4 import BeautifulSoup
+from pydantic import BaseModel
+
+
+AgentEditMode = Literal["slide", "element"]
+
+
+class SlideEditAgentRequest(BaseModel):
+    projectId: str
+    slideIndex: int
+    userRequest: str
+    chatHistory: Optional[List[Dict[str, Any]]] = None
+    mode: AgentEditMode = "slide"
+    slideTitle: Optional[str] = None
+    slideContent: Optional[str] = None
+    slideOutline: Optional[Dict[str, Any]] = None
+    projectInfo: Optional[Dict[str, Any]] = None
+    selectedElementHtml: Optional[str] = None
+    selectedElementId: Optional[str] = None
+    slideScreenshot: Optional[str] = None
+    elementScreenshot: Optional[str] = None
+    images: Optional[List[Dict[str, Any]]] = None
+    visionEnabled: bool = False
+    maxIterations: Optional[int] = None
+
+
+class SlideEditAgentApplyRequest(BaseModel):
+    proposalId: str
+    projectId: str
+    slideIndex: int
+    expectedBaseHash: str
+    htmlContent: str
+    slideData: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SlideEditAction:
+    thought: str
+    action: str
+    action_input: Dict[str, Any] = field(default_factory=dict)
+    raw_response: str = ""
+
+
+@dataclass
+class SlideEditValidationResult:
+    valid: bool
+    errors: List[str]
+    warnings: List[str]
+    sanitized_html: str
+
+
+@dataclass
+class SlideEditProposal:
+    proposal_id: str
+    base_hash: str
+    summary: str
+    changed_slide_indices: List[int]
+    html_content: str
+    validation: SlideEditValidationResult
+    tool_transcript: List[Dict[str, Any]]
+    slide_data: Dict[str, Any]
+    created_at: float
+
+    def to_public_dict(self) -> Dict[str, Any]:
+        return {
+            "proposalId": self.proposal_id,
+            "baseHash": self.base_hash,
+            "summary": self.summary,
+            "changedSlideIndices": self.changed_slide_indices,
+            "htmlContent": self.html_content,
+            "validation": {
+                "valid": self.validation.valid,
+                "errors": self.validation.errors,
+                "warnings": self.validation.warnings,
+            },
+            "toolTranscript": self.tool_transcript,
+            "slideData": self.slide_data,
+            "createdAt": self.created_at,
+        }
+
+
+def compute_slide_html_hash(html: str) -> str:
+    normalized = (html or "").strip().encode("utf-8")
+    return hashlib.sha256(normalized).hexdigest()
+
+
+def coerce_agent_max_iterations(raw_value: Any) -> int:
+    try:
+        if raw_value is not None:
+            return max(2, min(12, int(raw_value)))
+    except (TypeError, ValueError):
+        pass
+    return 6
+
+
+def _extract_json_payload(text: str) -> Optional[Dict[str, Any]]:
+    if not text:
+        return None
+
+    cleaned = text.strip()
+    fenced = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", cleaned, re.IGNORECASE)
+    if fenced:
+        cleaned = fenced.group(1).strip()
+
+    try:
+        parsed = json.loads(cleaned)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        pass
+
+    object_match = re.search(r"\{[\s\S]*\}", cleaned)
+    if object_match:
+        try:
+            parsed = json.loads(object_match.group(0))
+            return parsed if isinstance(parsed, dict) else None
+        except json.JSONDecodeError:
+            return None
+
+    return None
+
+
+def parse_agent_action(text: str) -> SlideEditAction:
+    payload = _extract_json_payload(text or "")
+    if not payload:
+        summary = (text or "").strip() or "Agent returned an empty response."
+        return SlideEditAction(
+            thought="Model response was not structured; treating it as final summary.",
+            action="final",
+            action_input={"summary": summary},
+            raw_response=text or "",
+        )
+
+    action_input = payload.get("action_input") or payload.get("input") or {}
+    if not isinstance(action_input, dict):
+        action_input = {"value": action_input}
+
+    action_name = str(payload.get("action") or payload.get("tool") or "final")
+    return SlideEditAction(
+        thought=str(payload.get("thought") or payload.get("reasoning") or "").strip(),
+        action=action_name.strip().lower().replace("-", "_"),
+        action_input=action_input,
+        raw_response=text or "",
+    )
+
+
+def strip_agent_ids(html: str) -> str:
+    soup = BeautifulSoup(html or "", "html.parser")
+    for node in soup.find_all(True):
+        for attr in ("data-agent-id", "data-quick-ai-id"):
+            if attr in node.attrs:
+                del node.attrs[attr]
+    return str(soup).strip()
+
+
+def sanitize_slide_html(html: str) -> str:
+    soup = BeautifulSoup(html or "", "html.parser")
+
+    for script in soup.find_all("script"):
+        script.decompose()
+
+    for node in soup.find_all(True):
+        for attr in list(getattr(node, "attrs", {}).keys()):
+            attr_lower = (attr or "").lower()
+            value = node.attrs.get(attr)
+            value_text = " ".join(value) if isinstance(value, list) else str(value or "")
+            value_lower = value_text.strip().lower()
+            if attr_lower.startswith("on"):
+                del node.attrs[attr]
+                continue
+            if "javascript:" in value_lower:
+                del node.attrs[attr]
+                continue
+            if attr_lower == "data-agent-id":
+                del node.attrs[attr]
+
+    return str(soup).strip()
+
+
+class _SlideHtmlStructureParser(HTMLParser):
+    _VOID_ELEMENTS = {
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    }
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.stack: List[str] = []
+        self.errors: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs: List[tuple[str, Optional[str]]]) -> None:
+        tag_name = tag.lower()
+        if tag_name not in self._VOID_ELEMENTS:
+            self.stack.append(tag_name)
+
+    def handle_startendtag(self, tag: str, attrs: List[tuple[str, Optional[str]]]) -> None:
+        return None
+
+    def handle_endtag(self, tag: str) -> None:
+        tag_name = tag.lower()
+        if tag_name in self._VOID_ELEMENTS:
+            return
+        if not self.stack:
+            self.errors.append("html is malformed")
+            return
+        if self.stack[-1] == tag_name:
+            self.stack.pop()
+            return
+        self.errors.append("html is malformed")
+
+    def close(self) -> None:
+        super().close()
+        if self.stack:
+            self.errors.append("html is malformed")
+
+
+def _find_html_structure_errors(html: str) -> List[str]:
+    parser = _SlideHtmlStructureParser()
+    try:
+        parser.feed(html)
+        parser.close()
+    except Exception:
+        return ["html is malformed"]
+    return list(dict.fromkeys(parser.errors))
+
+
+def validate_slide_html(html: str) -> SlideEditValidationResult:
+    errors: List[str] = []
+    warnings: List[str] = []
+    original = html or ""
+    original_lower = original.lower()
+
+    if not original.strip():
+        errors.append("html content is required")
+        return SlideEditValidationResult(False, errors, warnings, "")
+
+    if "<script" in original_lower:
+        errors.append("script tags are not allowed")
+
+    original_soup = BeautifulSoup(original, "html.parser")
+    if any(attr.lower().startswith("on") for tag in original_soup.find_all(True) for attr in tag.attrs):
+        errors.append("inline event handlers are not allowed")
+
+    if "javascript:" in original_lower:
+        errors.append("javascript urls are not allowed")
+
+    errors.extend(_find_html_structure_errors(original))
+
+    sanitized = sanitize_slide_html(original)
+    soup = BeautifulSoup(sanitized, "html.parser")
+    if not soup.find(True):
+        errors.append("html must contain at least one element")
+
+    root_text = soup.get_text(" ", strip=True)
+    has_media = bool(soup.find(["img", "svg", "canvas", "video", "picture"]))
+    if not root_text and not has_media:
+        warnings.append("slide has no visible text or media")
+
+    return SlideEditValidationResult(
+        valid=not errors,
+        errors=list(dict.fromkeys(errors)),
+        warnings=warnings,
+        sanitized_html=sanitized,
+    )
+
+
+EventEmitter = Callable[[Dict[str, Any]], Awaitable[None]]

--- a/src/landppt/services/slide/slide_edit_agent_service.py
+++ b/src/landppt/services/slide/slide_edit_agent_service.py
@@ -169,12 +169,24 @@ def _attribute_value_text(value: Any) -> str:
     return str(value or "")
 
 
+def _attribute_value_scheme_text(value: Any) -> str:
+    return re.sub(r"[\x00-\x20]+", "", _attribute_value_text(value)).lower()
+
+
 def _has_javascript_attribute_value(soup: BeautifulSoup) -> bool:
     for node in soup.find_all(True):
         for value in getattr(node, "attrs", {}).values():
-            if "javascript:" in _attribute_value_text(value).strip().lower():
+            if "javascript:" in _attribute_value_scheme_text(value):
                 return True
     return False
+
+
+def _has_srcdoc_attribute(soup: BeautifulSoup) -> bool:
+    return any(
+        attr.lower() == "srcdoc"
+        for tag in soup.find_all(True)
+        for attr in getattr(tag, "attrs", {})
+    )
 
 
 def sanitize_slide_html(html: str) -> str:
@@ -187,11 +199,13 @@ def sanitize_slide_html(html: str) -> str:
         for attr in list(getattr(node, "attrs", {}).keys()):
             attr_lower = (attr or "").lower()
             value = node.attrs.get(attr)
-            value_lower = _attribute_value_text(value).strip().lower()
             if attr_lower.startswith("on"):
                 del node.attrs[attr]
                 continue
-            if "javascript:" in value_lower:
+            if attr_lower == "srcdoc":
+                del node.attrs[attr]
+                continue
+            if "javascript:" in _attribute_value_scheme_text(value):
                 del node.attrs[attr]
                 continue
             if attr_lower == "data-agent-id":
@@ -278,6 +292,9 @@ def validate_slide_html(html: str) -> SlideEditValidationResult:
 
     if "javascript:" in original_lower or _has_javascript_attribute_value(original_soup):
         errors.append("javascript urls are not allowed")
+
+    if _has_srcdoc_attribute(original_soup):
+        errors.append("srcdoc attributes are not allowed")
 
     errors.extend(_find_html_structure_errors(original))
 

--- a/src/landppt/services/slide/slide_edit_agent_service.py
+++ b/src/landppt/services/slide/slide_edit_agent_service.py
@@ -778,3 +778,224 @@ class SlideEditToolRunner:
 
 
 EventEmitter = Callable[[Dict[str, Any]], Awaitable[None]]
+
+
+class SlideEditAgentService:
+    async def _emit(
+        self, event_callback: Optional[EventEmitter], event: Dict[str, Any]
+    ) -> None:
+        if event_callback:
+            await event_callback(event)
+
+    async def run_agent(
+        self,
+        request: SlideEditAgentRequest,
+        user_ppt_service: Any,
+        event_callback: Optional[EventEmitter] = None,
+    ) -> SlideEditProposal:
+        context = SlideEditAgentContext.from_request(request)
+        runner = SlideEditToolRunner(context)
+        max_iterations = coerce_agent_max_iterations(request.maxIterations)
+        role = (
+            "vision_analysis"
+            if request.visionEnabled
+            and (request.slideScreenshot or request.elementScreenshot or request.images)
+            else "editor"
+        )
+
+        await self._emit(
+            event_callback,
+            {
+                "type": "agent_start",
+                "projectId": request.projectId,
+                "slideIndex": request.slideIndex,
+                "mode": request.mode,
+                "maxIterations": max_iterations,
+                "tools": runner.available_tool_names(),
+            },
+        )
+
+        scratchpad: List[Dict[str, Any]] = []
+        for iteration in range(1, max_iterations + 1):
+            prompt = self._build_prompt(request, runner, scratchpad, max_iterations)
+            response = await user_ppt_service._chat_completion_for_role(
+                role,
+                messages=[
+                    self._ai_message(
+                        "system",
+                        "You are LandPPT's slide editing agent. Return one JSON action per turn.",
+                    ),
+                    self._ai_message("user", prompt),
+                ],
+            )
+            action = parse_agent_action(response.content or "")
+
+            await self._emit(
+                event_callback,
+                {
+                    "type": "agent_step",
+                    "iteration": iteration,
+                    "thought": action.thought,
+                    "action": action.action,
+                    "actionInput": action.action_input,
+                },
+            )
+
+            if action.action == "final":
+                summary = str(
+                    action.action_input.get("summary")
+                    or action.thought
+                    or "Prepared slide edit proposal."
+                )
+                proposal = runner.build_proposal(summary)
+                await self._emit_validation_and_draft(event_callback, proposal)
+                return proposal
+
+            await self._emit(
+                event_callback,
+                {
+                    "type": "tool_call",
+                    "iteration": iteration,
+                    "tool": action.action,
+                    "toolInput": action.action_input,
+                    "thought": action.thought,
+                },
+            )
+            observation = await runner.execute_tool(action.action, action.action_input)
+            await self._emit(
+                event_callback,
+                {
+                    "type": "tool_result",
+                    "iteration": iteration,
+                    "tool": action.action,
+                    "success": observation.get("success", False),
+                    "observation": observation,
+                },
+            )
+            scratchpad.append(
+                {
+                    "iteration": iteration,
+                    "thought": action.thought,
+                    "action": action.action,
+                    "action_input": action.action_input,
+                    "observation": self._compact_observation(observation),
+                }
+            )
+
+        proposal = runner.build_proposal(
+            "Reached the maximum edit iterations and prepared the current draft."
+        )
+        await self._emit_validation_and_draft(event_callback, proposal)
+        return proposal
+
+    def _ai_message(self, role: str, content: str):
+        from ...ai import AIMessage, MessageRole
+
+        mapped_role = MessageRole.SYSTEM if role == "system" else MessageRole.USER
+        return AIMessage(role=mapped_role, content=content)
+
+    async def _emit_validation_and_draft(
+        self, event_callback: Optional[EventEmitter], proposal: SlideEditProposal
+    ) -> None:
+        await self._emit(
+            event_callback,
+            {
+                "type": "validation_result",
+                "valid": proposal.validation.valid,
+                "errors": proposal.validation.errors,
+                "warnings": proposal.validation.warnings,
+            },
+        )
+        await self._emit(
+            event_callback,
+            {"type": "draft_ready", "proposal": proposal.to_public_dict()},
+        )
+        await self._emit(
+            event_callback,
+            {
+                "type": "needs_confirmation",
+                "proposalId": proposal.proposal_id,
+                "message": "Review the draft before applying it.",
+            },
+        )
+
+    def _build_prompt(
+        self,
+        request: SlideEditAgentRequest,
+        runner: SlideEditToolRunner,
+        scratchpad: List[Dict[str, Any]],
+        max_iterations: int,
+    ) -> str:
+        context = {
+            "project": request.projectInfo or {},
+            "slide_index": request.slideIndex,
+            "slide_title": request.slideTitle,
+            "slide_outline": request.slideOutline or {},
+            "mode": request.mode,
+            "selected_element_id": request.selectedElementId,
+            "selected_element_html": request.selectedElementHtml,
+            "user_request": request.userRequest,
+            "current_html": runner.current_html,
+            "available_tools": self._tool_schemas(),
+            "scratchpad": scratchpad,
+            "max_iterations": max_iterations,
+        }
+        return (
+            "Use a ReAct loop to edit this PPT slide. Choose exactly one action. "
+            "Use final when the draft is ready. Return strict JSON only.\n\n"
+            + json.dumps(context, ensure_ascii=False, indent=2)
+        )
+
+    def _tool_schemas(self) -> List[Dict[str, Any]]:
+        return [
+            {"name": "get_project_context", "input": {}},
+            {"name": "get_slide", "input": {"slide_index": "integer"}},
+            {"name": "list_slides", "input": {}},
+            {"name": "inspect_slide_html", "input": {"slide_index": "integer"}},
+            {
+                "name": "select_elements",
+                "input": {"selector": "string", "text": "string"},
+            },
+            {"name": "replace_slide_html", "input": {"html": "string"}},
+            {
+                "name": "replace_element_html",
+                "input": {"element_id": "string", "html": "string"},
+            },
+            {
+                "name": "update_text",
+                "input": {
+                    "selector": "string",
+                    "element_id": "string",
+                    "text": "string",
+                },
+            },
+            {
+                "name": "update_style",
+                "input": {
+                    "selector": "string",
+                    "element_id": "string",
+                    "styles": "object",
+                },
+            },
+            {
+                "name": "insert_element",
+                "input": {"parent_selector": "string", "html": "string"},
+            },
+            {
+                "name": "delete_element",
+                "input": {"selector": "string", "element_id": "string"},
+            },
+            {"name": "validate_slide_html", "input": {}},
+            {"name": "preview_patch", "input": {}},
+        ]
+
+    def _compact_observation(self, observation: Dict[str, Any]) -> Dict[str, Any]:
+        compact = {
+            "success": observation.get("success", False),
+            "summary": observation.get("summary") or observation.get("error") or "",
+        }
+        if observation.get("errors"):
+            compact["errors"] = observation["errors"]
+        if observation.get("warnings"):
+            compact["warnings"] = observation["warnings"]
+        return compact

--- a/src/landppt/services/slide/slide_edit_agent_service.py
+++ b/src/landppt/services/slide/slide_edit_agent_service.py
@@ -817,18 +817,21 @@ class SlideEditAgentService:
 
         scratchpad: List[Dict[str, Any]] = []
         for iteration in range(1, max_iterations + 1):
-            prompt = self._build_prompt(request, runner, scratchpad, max_iterations)
-            response = await user_ppt_service._chat_completion_for_role(
-                role,
-                messages=[
-                    self._ai_message(
-                        "system",
-                        "You are LandPPT's slide editing agent. Return one JSON action per turn.",
-                    ),
-                    self._ai_message("user", prompt),
-                ],
-            )
-            action = parse_agent_action(response.content or "")
+            try:
+                prompt = self._build_prompt(request, runner, scratchpad, max_iterations)
+                response = await user_ppt_service._chat_completion_for_role(
+                    role,
+                    messages=self._build_messages(request, prompt),
+                )
+                action = parse_agent_action(response.content or "")
+            except Exception as exc:
+                await self._emit_error(
+                    event_callback,
+                    exc,
+                    phase="model",
+                    iteration=iteration,
+                )
+                raise
 
             await self._emit(
                 event_callback,
@@ -861,7 +864,19 @@ class SlideEditAgentService:
                     "thought": action.thought,
                 },
             )
-            observation = await runner.execute_tool(action.action, action.action_input)
+            try:
+                observation = await runner.execute_tool(
+                    action.action, action.action_input
+                )
+            except Exception as exc:
+                await self._emit_error(
+                    event_callback,
+                    exc,
+                    phase="tool",
+                    iteration=iteration,
+                    tool=action.action,
+                )
+                raise
             await self._emit(
                 event_callback,
                 {
@@ -888,11 +903,31 @@ class SlideEditAgentService:
         await self._emit_validation_and_draft(event_callback, proposal)
         return proposal
 
-    def _ai_message(self, role: str, content: str):
+    def _ai_message(self, role: str, content: Any):
         from ...ai import AIMessage, MessageRole
 
         mapped_role = MessageRole.SYSTEM if role == "system" else MessageRole.USER
         return AIMessage(role=mapped_role, content=content)
+
+    def _build_messages(self, request: SlideEditAgentRequest, prompt: str) -> List[Any]:
+        messages = [
+            self._ai_message(
+                "system",
+                "You are LandPPT's slide editing agent. Return one JSON action per turn.",
+            )
+        ]
+        vision_urls = self._vision_image_urls(request)
+        if request.visionEnabled and vision_urls:
+            from ...ai.base import ImageContent, TextContent
+
+            user_content = [TextContent(text=prompt)]
+            user_content.extend(
+                ImageContent(image_url={"url": url}) for url in vision_urls
+            )
+            messages.append(self._ai_message("user", user_content))
+        else:
+            messages.append(self._ai_message("user", prompt))
+        return messages
 
     async def _emit_validation_and_draft(
         self, event_callback: Optional[EventEmitter], proposal: SlideEditProposal
@@ -919,6 +954,27 @@ class SlideEditAgentService:
             },
         )
 
+    async def _emit_error(
+        self,
+        event_callback: Optional[EventEmitter],
+        error: Exception,
+        *,
+        phase: str,
+        iteration: Optional[int] = None,
+        tool: Optional[str] = None,
+    ) -> None:
+        event: Dict[str, Any] = {
+            "type": "error",
+            "phase": phase,
+            "message": str(error) or error.__class__.__name__,
+            "errorType": error.__class__.__name__,
+        }
+        if iteration is not None:
+            event["iteration"] = iteration
+        if tool:
+            event["tool"] = tool
+        await self._emit(event_callback, event)
+
     def _build_prompt(
         self,
         request: SlideEditAgentRequest,
@@ -936,7 +992,8 @@ class SlideEditAgentService:
             "selected_element_html": request.selectedElementHtml,
             "user_request": request.userRequest,
             "current_html": runner.current_html,
-            "available_tools": self._tool_schemas(),
+            "vision": self._vision_context(request),
+            "available_tools": self._tool_schemas(runner),
             "scratchpad": scratchpad,
             "max_iterations": max_iterations,
         }
@@ -946,22 +1003,96 @@ class SlideEditAgentService:
             + json.dumps(context, ensure_ascii=False, indent=2)
         )
 
-    def _tool_schemas(self) -> List[Dict[str, Any]]:
-        return [
-            {"name": "get_project_context", "input": {}},
-            {"name": "get_slide", "input": {"slide_index": "integer"}},
-            {"name": "list_slides", "input": {}},
-            {"name": "inspect_slide_html", "input": {"slide_index": "integer"}},
-            {
+    def _vision_context(self, request: SlideEditAgentRequest) -> Dict[str, Any]:
+        attachments: List[Dict[str, Any]] = []
+        if request.slideScreenshot:
+            attachments.append(
+                {
+                    "source": "slide_screenshot",
+                    "attached": request.visionEnabled,
+                    "url": self._prompt_safe_image_url(request.slideScreenshot),
+                }
+            )
+        if request.elementScreenshot:
+            attachments.append(
+                {
+                    "source": "element_screenshot",
+                    "attached": request.visionEnabled,
+                    "url": self._prompt_safe_image_url(request.elementScreenshot),
+                }
+            )
+        for index, image in enumerate(request.images or [], start=1):
+            if not isinstance(image, dict):
+                continue
+            url = str(image.get("url") or "")
+            attachments.append(
+                {
+                    "source": f"reference_image_{index}",
+                    "name": image.get("name"),
+                    "size": image.get("size"),
+                    "attached": bool(request.visionEnabled and url),
+                    "url": self._prompt_safe_image_url(url),
+                }
+            )
+
+        return {
+            "enabled": request.visionEnabled,
+            "uses_vision_model": bool(
+                request.visionEnabled and self._vision_image_urls(request)
+            ),
+            "attached_image_count": (
+                len(self._vision_image_urls(request)) if request.visionEnabled else 0
+            ),
+            "attachments": attachments,
+            "instruction": (
+                "When vision attachments are present, inspect them for visual layout, "
+                "text, color, spacing, and selected-element context before choosing an action."
+            ),
+        }
+
+    def _vision_image_urls(self, request: SlideEditAgentRequest) -> List[str]:
+        urls = [
+            str(url)
+            for url in (request.slideScreenshot, request.elementScreenshot)
+            if url
+        ]
+        for image in request.images or []:
+            if not isinstance(image, dict):
+                continue
+            url = image.get("url")
+            if url:
+                urls.append(str(url))
+        return urls
+
+    def _prompt_safe_image_url(self, url: str) -> str:
+        if not url:
+            return ""
+        if url.startswith("data:image"):
+            return "[attached data URL omitted from text prompt]"
+        return url
+
+    def _tool_schemas(self, runner: SlideEditToolRunner) -> List[Dict[str, Any]]:
+        schema_by_name = {
+            "get_project_context": {"name": "get_project_context", "input": {}},
+            "get_slide": {"name": "get_slide", "input": {"slide_index": "integer"}},
+            "list_slides": {"name": "list_slides", "input": {}},
+            "inspect_slide_html": {
+                "name": "inspect_slide_html",
+                "input": {"slide_index": "integer"},
+            },
+            "select_elements": {
                 "name": "select_elements",
                 "input": {"selector": "string", "text": "string"},
             },
-            {"name": "replace_slide_html", "input": {"html": "string"}},
-            {
+            "replace_slide_html": {
+                "name": "replace_slide_html",
+                "input": {"html": "string"},
+            },
+            "replace_element_html": {
                 "name": "replace_element_html",
                 "input": {"element_id": "string", "html": "string"},
             },
-            {
+            "update_text": {
                 "name": "update_text",
                 "input": {
                     "selector": "string",
@@ -969,7 +1100,7 @@ class SlideEditAgentService:
                     "text": "string",
                 },
             },
-            {
+            "update_style": {
                 "name": "update_style",
                 "input": {
                     "selector": "string",
@@ -977,17 +1108,22 @@ class SlideEditAgentService:
                     "styles": "object",
                 },
             },
-            {
+            "insert_element": {
                 "name": "insert_element",
                 "input": {"parent_selector": "string", "html": "string"},
             },
-            {
+            "delete_element": {
                 "name": "delete_element",
                 "input": {"selector": "string", "element_id": "string"},
             },
-            {"name": "validate_slide_html", "input": {}},
-            {"name": "preview_patch", "input": {}},
-        ]
+            "validate_slide_html": {"name": "validate_slide_html", "input": {}},
+            "preview_patch": {"name": "preview_patch", "input": {}},
+        }
+        tool_names = runner.available_tool_names()
+        missing = [name for name in tool_names if name not in schema_by_name]
+        if missing:
+            raise ValueError(f"Missing slide edit tool schemas: {', '.join(missing)}")
+        return [schema_by_name[name] for name in tool_names]
 
     def _compact_observation(self, observation: Dict[str, Any]) -> Dict[str, Any]:
         compact = {

--- a/src/landppt/services/slide/slide_edit_agent_service.py
+++ b/src/landppt/services/slide/slide_edit_agent_service.py
@@ -682,13 +682,29 @@ class SlideEditToolRunner:
 
     def _tool_insert_element(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
         soup = self._soup()
-        parent, error = self._resolve_one(
-            soup,
-            {"selector": tool_input.get("parent_selector") or "body"},
-            "insert_element",
-        )
-        if error:
-            return error
+        parent_selector = str(tool_input.get("parent_selector") or "").strip()
+        element_id = str(tool_input.get("element_id") or "").strip()
+        if not parent_selector and not element_id:
+            return {
+                "success": False,
+                "tool": "insert_element",
+                "error": "insert_element requires parent_selector or element_id",
+            }
+        if element_id:
+            parent = soup.find(attrs={"data-agent-id": element_id}) or soup.find(
+                attrs={"data-quick-ai-id": element_id}
+            )
+            if not parent:
+                return {
+                    "success": False,
+                    "tool": "insert_element",
+                    "error": f'target element id "{element_id}" not found',
+                }
+        else:
+            try:
+                parent = soup.select_one(parent_selector)
+            except Exception as exc:
+                return self._invalid_selector_error("insert_element", parent_selector, exc)
         fragment, error = self._validate_fragment_html(
             "insert_element",
             tool_input.get("html"),

--- a/src/landppt/services/slide/slide_edit_agent_service.py
+++ b/src/landppt/services/slide/slide_edit_agent_service.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import time
-import uuid
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional
@@ -163,6 +161,20 @@ def strip_agent_ids(html: str) -> str:
     return str(soup).strip()
 
 
+def _attribute_value_text(value: Any) -> str:
+    if isinstance(value, list):
+        return " ".join(str(item) for item in value)
+    return str(value or "")
+
+
+def _has_javascript_attribute_value(soup: BeautifulSoup) -> bool:
+    for node in soup.find_all(True):
+        for value in getattr(node, "attrs", {}).values():
+            if "javascript:" in _attribute_value_text(value).strip().lower():
+                return True
+    return False
+
+
 def sanitize_slide_html(html: str) -> str:
     soup = BeautifulSoup(html or "", "html.parser")
 
@@ -173,8 +185,7 @@ def sanitize_slide_html(html: str) -> str:
         for attr in list(getattr(node, "attrs", {}).keys()):
             attr_lower = (attr or "").lower()
             value = node.attrs.get(attr)
-            value_text = " ".join(value) if isinstance(value, list) else str(value or "")
-            value_lower = value_text.strip().lower()
+            value_lower = _attribute_value_text(value).strip().lower()
             if attr_lower.startswith("on"):
                 del node.attrs[attr]
                 continue
@@ -263,7 +274,7 @@ def validate_slide_html(html: str) -> SlideEditValidationResult:
     if any(attr.lower().startswith("on") for tag in original_soup.find_all(True) for attr in tag.attrs):
         errors.append("inline event handlers are not allowed")
 
-    if "javascript:" in original_lower:
+    if "javascript:" in original_lower or _has_javascript_attribute_value(original_soup):
         errors.append("javascript urls are not allowed")
 
     errors.extend(_find_html_structure_errors(original))

--- a/src/landppt/services/slide/slide_edit_agent_service.py
+++ b/src/landppt/services/slide/slide_edit_agent_service.py
@@ -448,6 +448,35 @@ class SlideEditToolRunner:
     def _set_html_from_soup(self, soup: BeautifulSoup) -> None:
         self.current_html = str(soup).strip()
 
+    def _invalid_selector_error(
+        self, tool_name: str, selector: str, error: Exception
+    ) -> Dict[str, Any]:
+        return {
+            "success": False,
+            "tool": tool_name,
+            "error": f"invalid selector: {selector}",
+            "details": str(error),
+        }
+
+    def _validate_fragment_html(
+        self, tool_name: str, html: Any, empty_error: str
+    ) -> tuple[Optional[BeautifulSoup], Optional[Dict[str, Any]]]:
+        fragment_html = str(html or "").strip()
+        validation = validate_slide_html(fragment_html)
+        if not validation.sanitized_html:
+            return None, {"success": False, "tool": tool_name, "error": empty_error}
+        if not validation.valid:
+            return None, {
+                "success": False,
+                "tool": tool_name,
+                "error": "fragment html failed validation",
+                "errors": validation.errors,
+            }
+        fragment = BeautifulSoup(validation.sanitized_html, "html.parser")
+        if not fragment.find(True):
+            return None, {"success": False, "tool": tool_name, "error": empty_error}
+        return fragment, None
+
     def _tool_get_project_context(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
         return {
             "success": True,
@@ -511,7 +540,10 @@ class SlideEditToolRunner:
         text = str(tool_input.get("text") or "").strip().lower()
         soup = self._soup()
         matches = []
-        candidates = soup.select(selector) if selector else soup.find_all(True)
+        try:
+            candidates = soup.select(selector) if selector else soup.find_all(True)
+        except Exception as exc:
+            return self._invalid_selector_error("select_elements", selector, exc)
         for idx, node in enumerate(candidates[:100], start=1):
             node_text = node.get_text(" ", strip=True)
             if text and text not in node_text.lower():
@@ -527,20 +559,30 @@ class SlideEditToolRunner:
             "summary": f"Selected {len(matches)} elements.",
         }
 
-    def _resolve_one(self, soup: BeautifulSoup, tool_input: Dict[str, Any]):
+    def _resolve_one(
+        self, soup: BeautifulSoup, tool_input: Dict[str, Any], tool_name: str
+    ) -> tuple[Any, Optional[Dict[str, Any]]]:
         selector = str(tool_input.get("selector") or "").strip()
         element_id = str(
             tool_input.get("element_id") or self.context.selected_element_id or ""
         ).strip()
         if element_id:
-            found = soup.select_one(f'[data-agent-id="{element_id}"]') or soup.select_one(
-                f'[data-quick-ai-id="{element_id}"]'
+            found = soup.find(attrs={"data-agent-id": element_id}) or soup.find(
+                attrs={"data-quick-ai-id": element_id}
             )
             if found:
-                return found
+                return found, None
+            return None, {
+                "success": False,
+                "tool": tool_name,
+                "error": f'target element id "{element_id}" not found',
+            }
         if selector:
-            return soup.select_one(selector)
-        return soup.find(True)
+            try:
+                return soup.select_one(selector), None
+            except Exception as exc:
+                return None, self._invalid_selector_error(tool_name, selector, exc)
+        return soup.find(True), None
 
     def _tool_replace_slide_html(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
         html = str(tool_input.get("html") or tool_input.get("value") or "").strip()
@@ -561,21 +603,23 @@ class SlideEditToolRunner:
 
     def _tool_replace_element_html(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
         soup = self._soup()
-        target = self._resolve_one(soup, tool_input)
+        target, error = self._resolve_one(soup, tool_input, "replace_element_html")
+        if error:
+            return error
         if not target:
             return {
                 "success": False,
                 "tool": "replace_element_html",
                 "error": "target element not found",
             }
-        fragment = BeautifulSoup(str(tool_input.get("html") or ""), "html.parser")
+        fragment, error = self._validate_fragment_html(
+            "replace_element_html",
+            tool_input.get("html"),
+            "replacement element html is empty",
+        )
+        if error:
+            return error
         replacement = fragment.find(True)
-        if not replacement:
-            return {
-                "success": False,
-                "tool": "replace_element_html",
-                "error": "replacement element html is empty",
-            }
         element_id = str(
             tool_input.get("element_id") or self.context.selected_element_id or ""
         ).strip()
@@ -591,7 +635,9 @@ class SlideEditToolRunner:
 
     def _tool_update_text(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
         soup = self._soup()
-        target = self._resolve_one(soup, tool_input)
+        target, error = self._resolve_one(soup, tool_input, "update_text")
+        if error:
+            return error
         if not target:
             return {"success": False, "tool": "update_text", "error": "target element not found"}
         target.clear()
@@ -601,7 +647,9 @@ class SlideEditToolRunner:
 
     def _tool_update_style(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
         soup = self._soup()
-        target = self._resolve_one(soup, tool_input)
+        target, error = self._resolve_one(soup, tool_input, "update_style")
+        if error:
+            return error
         if not target:
             return {
                 "success": False,
@@ -630,8 +678,20 @@ class SlideEditToolRunner:
 
     def _tool_insert_element(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
         soup = self._soup()
-        parent = self._resolve_one(soup, {"selector": tool_input.get("parent_selector") or "body"})
-        fragment = BeautifulSoup(str(tool_input.get("html") or ""), "html.parser")
+        parent, error = self._resolve_one(
+            soup,
+            {"selector": tool_input.get("parent_selector") or "body"},
+            "insert_element",
+        )
+        if error:
+            return error
+        fragment, error = self._validate_fragment_html(
+            "insert_element",
+            tool_input.get("html"),
+            "parent or inserted element not found",
+        )
+        if error:
+            return error
         node = fragment.find(True)
         if not parent or not node:
             return {
@@ -645,7 +705,9 @@ class SlideEditToolRunner:
 
     def _tool_delete_element(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
         soup = self._soup()
-        target = self._resolve_one(soup, tool_input)
+        target, error = self._resolve_one(soup, tool_input, "delete_element")
+        if error:
+            return error
         if not target:
             return {"success": False, "tool": "delete_element", "error": "target element not found"}
         target.decompose()

--- a/src/landppt/web/route_modules/export_routes.py
+++ b/src/landppt/web/route_modules/export_routes.py
@@ -932,6 +932,7 @@ async def download_task_result(
 @router.get("/api/projects/{project_id}/export/html")
 async def export_project_html(
     project_id: str,
+    http_request: Request,
     user: User = Depends(get_current_user_required)
 ):
     """Export project as HTML ZIP package with slideshow index"""
@@ -944,8 +945,10 @@ async def export_project_html(
         if not project.slides_data or len(project.slides_data) == 0:
             raise HTTPException(status_code=400, detail="PPT not generated yet")
 
+        export_base_url = _resolve_export_base_url(http_request)
+
         # Create temporary directory and generate files in thread pool
-        zip_content = await run_blocking_io(_generate_html_export_sync, project)
+        zip_content = await run_blocking_io(_generate_html_export_sync, project, export_base_url)
 
         # URL encode the filename to handle Chinese characters
         zip_filename = f"{project.topic}_PPT.zip"

--- a/src/landppt/web/route_modules/export_support.py
+++ b/src/landppt/web/route_modules/export_support.py
@@ -460,7 +460,7 @@ class ImagePPTXExportRequest(BaseModel):
 ImagePPTXExportRequest.model_rebuild()
 
 
-def _generate_html_export_sync(project) -> bytes:
+def _generate_html_export_sync(project, base_url: Optional[str] = None) -> bytes:
     """同步生成HTML导出文件（在线程池中运行）"""
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
@@ -471,18 +471,17 @@ def _generate_html_export_sync(project) -> bytes:
         raw_dir = temp_path / "slides"
         raw_dir.mkdir()
 
+        export_base_url = (base_url or "").strip()
         slide_files = []
         for i, slide in enumerate(project.slides_data):
             slide_filename = f"slide_{i+1}.html"
             slide_files.append(slide_filename)
 
             raw_html = _wrap_raw_slide_html_sync(slide, project.topic)
+            if export_base_url:
+                raw_html = _prepare_html_for_file_based_export(raw_html, export_base_url)
             with open(raw_dir / slide_filename, 'w', encoding='utf-8') as f:
                 f.write(raw_html)
-
-            viewer_html = _generate_individual_slide_html_sync(slide, i+1, total_slides, project.topic)
-            with open(temp_path / slide_filename, 'w', encoding='utf-8') as f:
-                f.write(viewer_html)
 
         # Generate index.html projector page
         index_html = _generate_slideshow_index_sync(project, slide_files)
@@ -498,9 +497,8 @@ def _generate_html_export_sync(project) -> bytes:
             # Add index.html
             zipf.write(index_path, "index.html")
 
-            # Add viewer and raw slide files
+            # Add raw slide files only. The index projector loads these directly.
             for slide_file in slide_files:
-                zipf.write(temp_path / slide_file, slide_file)
                 zipf.write(raw_dir / slide_file, f"slides/{slide_file}")
 
         # Read ZIP file content
@@ -582,9 +580,8 @@ _PROJECTOR_STAGE_CSS = """
             background: #fff;
             transform-origin: top left;
         }
-        /* 透明遮罩：捕获幻灯片区域的鼠标/键盘事件（iframe内的事件不会冒泡到父页面），
-           并支持点击翻页 */
-        .stage-shield { position: fixed; inset: 0; z-index: 50; }
+        /* Keep the legacy shield non-interactive so slide links and widgets receive clicks. */
+        .stage-shield { position: fixed; inset: 0; z-index: 50; pointer-events: none; }
         body.ui-hidden .stage-shield { cursor: none; }
         .ctrl-btn {
             background: rgba(255,255,255,0.14);

--- a/src/landppt/web/route_modules/slide_edit_agent_routes.py
+++ b/src/landppt/web/route_modules/slide_edit_agent_routes.py
@@ -1,0 +1,235 @@
+"""
+Slide edit agent web routes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+
+from ...auth.middleware import get_current_user_required
+from ...database.models import User
+from ...services.db_project_manager import DatabaseProjectManager
+from ...services.slide.slide_edit_agent_service import (
+    SlideEditAgentApplyRequest,
+    SlideEditAgentRequest,
+    SlideEditAgentService,
+    compute_slide_html_hash,
+    validate_slide_html,
+)
+from .support import (
+    check_credits_for_operation,
+    consume_credits_for_operation,
+    get_ppt_service_for_user,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+_STREAM_HEADERS = {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Cache-Control",
+}
+
+
+def _sse(event: dict[str, Any]) -> str:
+    return f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+
+
+def _is_billable_agent_completion(event: dict[str, Any]) -> bool:
+    return event.get("type") in {"draft_ready", "final"}
+
+
+async def _charge_completed_agent_run(
+    *,
+    user_id: int,
+    request: SlideEditAgentRequest,
+    provider_name: str | None,
+) -> None:
+    try:
+        success, message = await consume_credits_for_operation(
+            user_id,
+            "ai_edit",
+            1,
+            description=f"AI Agent edit: slide {request.slideIndex} {request.slideTitle or ''}".strip(),
+            reference_id=request.projectId,
+            provider_name=provider_name,
+        )
+        if not success:
+            logger.warning("Slide edit agent credit charge failed: %s", message)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Slide edit agent credit charge raised: %s", exc, exc_info=True)
+
+
+@router.post("/api/ai/slide-edit-agent/stream")
+async def stream_slide_edit_agent(
+    request: SlideEditAgentRequest,
+    user: User = Depends(get_current_user_required),
+):
+    user_ppt_service = get_ppt_service_for_user(user.id)
+    role = "vision_analysis" if request.visionEnabled else "editor"
+    _, settings = await user_ppt_service.get_role_provider_async(role)
+    provider_name = settings.get("provider")
+
+    has_credits, required, balance = await check_credits_for_operation(
+        user.id,
+        "ai_edit",
+        1,
+        provider_name=provider_name,
+    )
+    if not has_credits:
+        return StreamingResponse(
+            iter(
+                [
+                    _sse(
+                        {
+                            "type": "error",
+                            "content": "",
+                            "error": (
+                                "Insufficient credits for AI edit. "
+                                f"Required: {required}, balance: {balance}."
+                            ),
+                        }
+                    )
+                ]
+            ),
+            media_type="text/event-stream",
+            headers=_STREAM_HEADERS,
+        )
+
+    async def event_stream():
+        charged = False
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+        async def emit(event: dict[str, Any]) -> None:
+            await queue.put(event)
+
+        async def run_agent_task() -> None:
+            try:
+                service = SlideEditAgentService()
+                await service.run_agent(request, user_ppt_service, emit)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Slide edit agent stream failed: %s", exc, exc_info=True)
+                await queue.put(
+                    {
+                        "type": "error",
+                        "content": "",
+                        "error": str(exc) or exc.__class__.__name__,
+                    }
+                )
+            finally:
+                await queue.put({"type": "_agent_done"})
+
+        task = asyncio.create_task(run_agent_task())
+        try:
+            while True:
+                event = await queue.get()
+                if event.get("type") == "_agent_done":
+                    break
+
+                yield _sse(event)
+
+                if _is_billable_agent_completion(event) and not charged:
+                    await _charge_completed_agent_run(
+                        user_id=user.id,
+                        request=request,
+                        provider_name=provider_name,
+                    )
+                    charged = True
+
+            await task
+        except asyncio.CancelledError:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            raise
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers=_STREAM_HEADERS,
+    )
+
+
+@router.post("/api/ai/slide-edit-agent/apply")
+async def apply_slide_edit_agent_proposal(
+    request: SlideEditAgentApplyRequest,
+    user: User = Depends(get_current_user_required),
+):
+    if request.slideIndex < 1:
+        raise HTTPException(
+            status_code=400,
+            detail="slideIndex must be 1-based and greater than 0",
+        )
+
+    user_ppt_service = get_ppt_service_for_user(user.id)
+    project = await user_ppt_service.project_manager.get_project(
+        request.projectId,
+        user_id=user.id,
+    )
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    slides_data = project.slides_data or []
+    zero_based_index = request.slideIndex - 1
+    if zero_based_index >= len(slides_data):
+        raise HTTPException(status_code=404, detail="Slide not found")
+
+    existing_slide = slides_data[zero_based_index] or {}
+    if not isinstance(existing_slide, dict):
+        existing_slide = {}
+
+    current_html = existing_slide.get("html_content") or ""
+    if compute_slide_html_hash(current_html) != request.expectedBaseHash:
+        raise HTTPException(
+            status_code=409,
+            detail="Slide changed after proposal was created",
+        )
+
+    validation = validate_slide_html(request.htmlContent)
+    if not validation.valid:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "errors": validation.errors,
+                "warnings": validation.warnings,
+            },
+        )
+
+    slide_data = {
+        **existing_slide,
+        **(request.slideData or {}),
+        "page_number": request.slideIndex,
+        "html_content": validation.sanitized_html,
+        "is_user_edited": True,
+    }
+
+    db_manager = DatabaseProjectManager()
+    saved = await db_manager.save_single_slide(
+        request.projectId,
+        zero_based_index,
+        slide_data,
+    )
+    if not saved:
+        raise HTTPException(status_code=500, detail="Failed to save slide")
+
+    return {
+        "success": True,
+        "proposalId": request.proposalId,
+        "slideIndex": request.slideIndex,
+        "slideData": slide_data,
+        "htmlContent": validation.sanitized_html,
+    }
+
+
+@router.post("/api/ai/slide-edit-agent/cancel")
+async def cancel_slide_edit_agent(user: User = Depends(get_current_user_required)):
+    return {"success": True}

--- a/src/landppt/web/route_modules/slide_edit_agent_routes.py
+++ b/src/landppt/web/route_modules/slide_edit_agent_routes.py
@@ -21,6 +21,7 @@ from ...services.slide.slide_edit_agent_service import (
     SlideEditAgentRequest,
     SlideEditAgentService,
     compute_slide_html_hash,
+    strip_agent_ids,
     validate_slide_html,
 )
 from .support import (
@@ -46,6 +47,13 @@ def _sse(event: dict[str, Any]) -> str:
 
 def _is_billable_agent_completion(event: dict[str, Any]) -> bool:
     return event.get("type") in {"draft_ready", "final"}
+
+
+def _agent_provider_role(request: SlideEditAgentRequest) -> str:
+    has_vision_input = bool(
+        request.slideScreenshot or request.elementScreenshot or request.images
+    )
+    return "vision_analysis" if request.visionEnabled and has_vision_input else "editor"
 
 
 async def _charge_completed_agent_run(
@@ -75,7 +83,7 @@ async def stream_slide_edit_agent(
     user: User = Depends(get_current_user_required),
 ):
     user_ppt_service = get_ppt_service_for_user(user.id)
-    role = "vision_analysis" if request.visionEnabled else "editor"
+    role = _agent_provider_role(request)
     _, settings = await user_ppt_service.get_role_provider_async(role)
     provider_name = settings.get("provider")
 
@@ -194,7 +202,8 @@ async def apply_slide_edit_agent_proposal(
             detail="Slide changed after proposal was created",
         )
 
-    validation = validate_slide_html(request.htmlContent)
+    cleaned_html = strip_agent_ids(request.htmlContent)
+    validation = validate_slide_html(cleaned_html)
     if not validation.valid:
         raise HTTPException(
             status_code=400,

--- a/src/landppt/web/route_modules/slide_edit_agent_routes.py
+++ b/src/landppt/web/route_modules/slide_edit_agent_routes.py
@@ -143,8 +143,6 @@ async def stream_slide_edit_agent(
                 if event.get("type") == "_agent_done":
                     break
 
-                yield _sse(event)
-
                 if _is_billable_agent_completion(event) and not charged:
                     await _charge_completed_agent_run(
                         user_id=user.id,
@@ -152,6 +150,8 @@ async def stream_slide_edit_agent(
                         provider_name=provider_name,
                     )
                     charged = True
+
+                yield _sse(event)
 
             await task
         except asyncio.CancelledError:
@@ -202,7 +202,17 @@ async def apply_slide_edit_agent_proposal(
             detail="Slide changed after proposal was created",
         )
 
-    cleaned_html = strip_agent_ids(request.htmlContent)
+    validation = validate_slide_html(request.htmlContent)
+    if not validation.valid:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "errors": validation.errors,
+                "warnings": validation.warnings,
+            },
+        )
+
+    cleaned_html = strip_agent_ids(validation.sanitized_html)
     validation = validate_slide_html(cleaned_html)
     if not validation.valid:
         raise HTTPException(

--- a/src/landppt/web/routes.py
+++ b/src/landppt/web/routes.py
@@ -11,6 +11,7 @@ from .route_modules.narration_routes import router as narration_router
 from .route_modules.outline_routes import router as outline_router
 from .route_modules.project_routes import router as project_router
 from .route_modules.share_routes import router as share_router
+from .route_modules.slide_edit_agent_routes import router as slide_edit_agent_router
 from .route_modules.slide_routes import router as slide_router
 from .route_modules.speech_script_routes import router as speech_script_router
 from .route_modules.template_routes import router as template_router
@@ -25,4 +26,5 @@ router.include_router(template_router)
 router.include_router(export_router)
 router.include_router(slide_router)
 router.include_router(ai_edit_router)
+router.include_router(slide_edit_agent_router)
 router.include_router(speech_script_router)

--- a/src/landppt/web/static/css/pages/project/slides_editor/projectSlidesEditor.css
+++ b/src/landppt/web/static/css/pages/project/slides_editor/projectSlidesEditor.css
@@ -1002,10 +1002,12 @@ body::before {
 
 /* 透明遮罩：捕获iframe上方的鼠标事件（iframe内的事件不会冒泡到父页面），
    并支持点击翻页 */
+/* The legacy shield must not intercept iframe clicks. */
 .slideshow-shield {
     position: absolute;
     inset: 0;
     z-index: 50;
+    pointer-events: none;
 }
 
 .slideshow-overlay.ui-hidden .slideshow-shield {

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js
@@ -416,6 +416,86 @@ function showHTMLPreview(htmlContent) {
 }
 
 // 应用AI更改
+function syncAppliedSlideHtml(slideIndex, htmlContent, slideData = {}) {
+    if (!Number.isInteger(slideIndex) || slideIndex < 0 || slideIndex >= slidesData.length) {
+        throw new Error(`无效的幻灯片索引: ${slideIndex}`);
+    }
+
+    slidesData[slideIndex] = {
+        ...slidesData[slideIndex],
+        ...(slideData || {}),
+        html_content: htmlContent,
+        is_user_edited: true
+    };
+
+    if (typeof setInitialSlideState === 'function') {
+        setInitialSlideState(slideIndex, htmlContent);
+    }
+
+    const slideFrame = document.getElementById('slideFrame');
+    if (slideFrame && slideIndex === currentSlideIndex) {
+        setSafeIframeContent(slideFrame, htmlContent);
+        setTimeout(() => {
+            if (typeof forceReinitializeIframeJS === 'function') {
+                forceReinitializeIframeJS(slideFrame);
+            }
+        }, 300);
+    }
+
+    const thumbnailIframe = document.querySelectorAll('.slide-thumbnail .slide-preview iframe')[slideIndex];
+    if (thumbnailIframe) {
+        setSafeIframeContent(thumbnailIframe, htmlContent);
+    }
+
+    const codeEditor = document.getElementById('codeEditor');
+    if (codeEditor && slideIndex === currentSlideIndex) {
+        if (codeMirrorEditor && isCodeMirrorInitialized) {
+            codeMirrorEditor.setValue(htmlContent);
+        } else {
+            codeEditor.value = htmlContent;
+        }
+    }
+}
+
+async function applyAgentProposal(proposal) {
+    if (!proposal || !proposal.htmlContent) {
+        throw new Error('Agent 未返回可应用的方案');
+    }
+
+    const slideIndexOneBased = parseInt(
+        proposal.slideIndex || (proposal.changedSlideIndices && proposal.changedSlideIndices[0]) || (currentSlideIndex + 1),
+        10
+    );
+    const slideIndexZeroBased = slideIndexOneBased - 1;
+
+    const response = await fetch('/api/ai/slide-edit-agent/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            proposalId: proposal.proposalId,
+            projectId: window.landpptEditorConfig.projectId,
+            slideIndex: slideIndexOneBased,
+            expectedBaseHash: proposal.baseHash,
+            htmlContent: proposal.htmlContent,
+            slideData: proposal.slideData || {}
+        })
+    });
+
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || !data.success) {
+        const detail = data.detail || data.error || `HTTP ${response.status}`;
+        throw new Error(typeof detail === 'string' ? detail : JSON.stringify(detail));
+    }
+
+    syncAppliedSlideHtml(
+        slideIndexZeroBased,
+        data.htmlContent || proposal.htmlContent,
+        data.slideData || proposal.slideData || {}
+    );
+    showNotification(`Agent 更改已应用并保存：第${slideIndexOneBased}页`, 'success');
+    return data;
+}
+
 async function applyAIChanges(newHtmlContent) {
     try {
         // 防御：若slides_data存在缺页导致错位，先按page_number/大纲归一化，避免错页写入
@@ -436,39 +516,8 @@ async function applyAIChanges(newHtmlContent) {
             throw new Error(`无效的幻灯片索引: ${targetSlideIndex}，总页数: ${slidesData.length}`);
         }
 
-        // 更新当前幻灯片数据
-        slidesData[targetSlideIndex].html_content = newHtmlContent;
-        if (typeof setInitialSlideState === 'function') {
-            setInitialSlideState(targetSlideIndex, newHtmlContent);
-        }
-
-        // 标记当前幻灯片为用户编辑状态
-        slidesData[targetSlideIndex].is_user_edited = true;
-
-        // 更新预览
-        const slideFrame = document.getElementById('slideFrame');
-        if (slideFrame) {
-            setSafeIframeContent(slideFrame, newHtmlContent);
-            setTimeout(() => {
-                forceReinitializeIframeJS(slideFrame);
-            }, 300);
-        }
-
-        // 更新缩略图
-        const thumbnailIframe = document.querySelectorAll('.slide-thumbnail .slide-preview iframe')[targetSlideIndex];
-        if (thumbnailIframe) {
-            setSafeIframeContent(thumbnailIframe, newHtmlContent);
-        }
-
-        // 更新代码编辑器
-        const codeEditor = document.getElementById('codeEditor');
-        if (codeEditor) {
-            if (codeMirrorEditor && isCodeMirrorInitialized) {
-                codeMirrorEditor.setValue(newHtmlContent);
-            } else {
-                codeEditor.value = newHtmlContent;
-            }
-        }
+        // 同步本地预览、缩略图和代码编辑器
+        syncAppliedSlideHtml(targetSlideIndex, newHtmlContent);
 
         // 保存到服务器 - 使用单个幻灯片保存API，确保使用正确的索引
         const saveSuccess = await saveSingleSlideToServer(targetSlideIndex, newHtmlContent);

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js
@@ -457,35 +457,77 @@ function syncAppliedSlideHtml(slideIndex, htmlContent, slideData = {}) {
     }
 }
 
-function syncQuickElementAgentResult(slideIndex, htmlContent, elementId) {
-    syncAppliedSlideHtml(slideIndex, htmlContent, slidesData[slideIndex] || {});
+function syncQuickElementAgentResult(slideIndex, htmlContent, elementId, elementPath = null) {
+    const slideFrame = document.getElementById('slideFrame');
+    const canSelectElement = slideFrame && slideIndex === currentSlideIndex && elementId;
+    const isCurrentIframeContent = canSelectElement
+        && typeof prepareHtmlForPreview === 'function'
+        && slideFrame.getAttribute('data-current-content') === prepareHtmlForPreview(htmlContent);
+    const shouldWaitForIframeLoad = canSelectElement && !isCurrentIframeContent;
+    let selectedElement = null;
+    let iframeLoadHandler = null;
 
     const selectAppliedElement = () => {
-        const slideFrame = document.getElementById('slideFrame');
         const iframeDoc = slideFrame && (slideFrame.contentDocument || slideFrame.contentWindow?.document);
         if (!iframeDoc || !elementId) return null;
 
-        const selected = iframeDoc.querySelector(`[data-quick-ai-id="${elementId}"]`);
+        let selected = iframeDoc.querySelector(`[data-quick-ai-id="${elementId}"]`);
+        if (!selected && elementPath && typeof findQuickAiElementByDomPath === 'function') {
+            selected = findQuickAiElementByDomPath(iframeDoc, elementPath);
+            if (selected) {
+                selected.setAttribute('data-quick-ai-id', elementId);
+            }
+        }
+
         if (selected && typeof selectQuickEditElement === 'function') {
             selectQuickEditElement(selected, { allowWhileAiSending: true });
         }
         return selected;
     };
 
-    const selected = selectAppliedElement();
-    if (!selected && elementId) {
-        const retrySelection = () => selectAppliedElement();
-        if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
-            window.requestAnimationFrame(() => {
-                if (!retrySelection()) {
-                    setTimeout(retrySelection, 350);
-                }
-            });
-        } else {
-            setTimeout(retrySelection, 350);
+    const runSelection = () => {
+        selectedElement = selectAppliedElement();
+        if (selectedElement && iframeLoadHandler) {
+            slideFrame.removeEventListener('load', iframeLoadHandler);
+            iframeLoadHandler = null;
         }
+        return selectedElement;
+    };
+
+    if (shouldWaitForIframeLoad) {
+        iframeLoadHandler = () => {
+            iframeLoadHandler = null;
+            if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+                window.requestAnimationFrame(runSelection);
+            } else {
+                setTimeout(runSelection, 0);
+            }
+        };
+        slideFrame.addEventListener('load', iframeLoadHandler, { once: true });
     }
-    return selected;
+
+    syncAppliedSlideHtml(slideIndex, htmlContent, slidesData[slideIndex] || {});
+
+    if (!canSelectElement) return null;
+
+    const retrySelection = () => {
+        if (!selectedElement) {
+            runSelection();
+        }
+    };
+    if (isCurrentIframeContent) {
+        retrySelection();
+    } else {
+        setTimeout(retrySelection, 800);
+        setTimeout(() => {
+            retrySelection();
+            if (iframeLoadHandler) {
+                slideFrame.removeEventListener('load', iframeLoadHandler);
+                iframeLoadHandler = null;
+            }
+        }, 1500);
+    }
+    return selectedElement;
 }
 
 async function applyAgentProposal(proposal) {

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js
@@ -457,6 +457,37 @@ function syncAppliedSlideHtml(slideIndex, htmlContent, slideData = {}) {
     }
 }
 
+function syncQuickElementAgentResult(slideIndex, htmlContent, elementId) {
+    syncAppliedSlideHtml(slideIndex, htmlContent, slidesData[slideIndex] || {});
+
+    const selectAppliedElement = () => {
+        const slideFrame = document.getElementById('slideFrame');
+        const iframeDoc = slideFrame && (slideFrame.contentDocument || slideFrame.contentWindow?.document);
+        if (!iframeDoc || !elementId) return null;
+
+        const selected = iframeDoc.querySelector(`[data-quick-ai-id="${elementId}"]`);
+        if (selected && typeof selectQuickEditElement === 'function') {
+            selectQuickEditElement(selected, { allowWhileAiSending: true });
+        }
+        return selected;
+    };
+
+    const selected = selectAppliedElement();
+    if (!selected && elementId) {
+        const retrySelection = () => selectAppliedElement();
+        if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(() => {
+                if (!retrySelection()) {
+                    setTimeout(retrySelection, 350);
+                }
+            });
+        } else {
+            setTimeout(retrySelection, 350);
+        }
+    }
+    return selected;
+}
+
 async function applyAgentProposal(proposal) {
     if (!proposal || !proposal.htmlContent) {
         throw new Error('Agent 未返回可应用的方案');

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiChat.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiChat.js
@@ -852,6 +852,57 @@ async function handleAgentStreamingResponse(response, waitingDiv) {
     }
 }
 
+async function collectAgentProposalFromStream(response, onEvent = null) {
+    if (!response || !response.body || typeof response.body.getReader !== 'function') {
+        throw new Error('Agent未返回可读取的流式响应');
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let proposal = null;
+
+    const processLine = (line) => {
+        if (!line.trim().startsWith('data: ')) return;
+        const dataStr = line.slice(6).trim();
+        if (!dataStr) return;
+
+        const event = JSON.parse(dataStr);
+        if (!event || event.type === '_agent_done') return;
+
+        if (onEvent) onEvent(event);
+        if (event.type === 'error') {
+            throw new Error(event.error || event.message || 'Agent编辑失败');
+        }
+        if (event.type === 'draft_ready' && event.proposal && !proposal) {
+            proposal = event.proposal;
+        }
+    };
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+            processLine(line);
+        }
+    }
+
+    buffer += decoder.decode();
+    if (buffer.trim()) {
+        processLine(buffer);
+    }
+
+    if (!proposal) {
+        throw new Error('Agent未返回可应用的编辑草稿');
+    }
+    return proposal;
+}
+
 // options:
 // - messageOverride: string (optional)
 // - appendUserMessage: boolean (default true)

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiChat.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiChat.js
@@ -874,7 +874,7 @@ async function collectAgentProposalFromStream(response, onEvent = null) {
         if (event.type === 'error') {
             throw new Error(event.error || event.message || 'Agent编辑失败');
         }
-        if (event.type === 'draft_ready' && event.proposal && !proposal) {
+        if ((event.type === 'draft_ready' || event.type === 'final') && event.proposal && !proposal) {
             proposal = event.proposal;
         }
     };

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiChat.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.aiChat.js
@@ -581,6 +581,277 @@ async function updateOutlineForSlideOperation(operation, slideIndex, slideData =
 }
 
 // 发送AI消息 - 使用流式输出
+function getAgentEventLabel(event) {
+    const type = event && event.type;
+    const labels = {
+        agent_start: '开始分析',
+        agent_step: '选择下一步',
+        tool_call: '调用工具',
+        tool_result: '工具结果',
+        validation_result: '校验结果',
+        draft_ready: '草稿就绪',
+        needs_confirmation: '等待确认',
+        final: '草稿就绪',
+        error: '出错'
+    };
+    return labels[type] || type || 'Agent 事件';
+}
+
+function compactAgentText(value, maxLength = 420) {
+    const text = typeof value === 'string' ? value : String(value ?? '');
+    if (text.length <= maxLength) {
+        return text;
+    }
+    return `${text.slice(0, maxLength)}...`;
+}
+
+function stringifyAgentPayload(payload) {
+    if (!payload || typeof payload !== 'object') {
+        return '';
+    }
+    try {
+        return JSON.stringify(payload, (key, value) => {
+            if (typeof value === 'string') {
+                return compactAgentText(value, 220);
+            }
+            return value;
+        }, 2);
+    } catch (error) {
+        return compactAgentText(String(payload));
+    }
+}
+
+function getAgentEventDetail(event) {
+    if (!event) {
+        return '';
+    }
+
+    if (event.type === 'agent_start') {
+        const slideLabel = event.slideIndex ? `第${event.slideIndex}页` : '';
+        return [slideLabel, event.mode ? `模式：${event.mode}` : ''].filter(Boolean).join(' · ');
+    }
+
+    if (event.type === 'tool_call') {
+        const input = stringifyAgentPayload(event.toolInput || event.actionInput || {});
+        return [event.tool || event.action || '', input].filter(Boolean).join('\n');
+    }
+
+    if (event.type === 'tool_result') {
+        const observation = event.observation || {};
+        return observation.summary || observation.error || (event.success ? '完成' : '失败');
+    }
+
+    if (event.type === 'validation_result') {
+        if (event.valid) {
+            return 'HTML 校验通过';
+        }
+        const errors = Array.isArray(event.errors) ? event.errors.join('；') : '';
+        return errors ? `HTML 校验失败：${errors}` : 'HTML 校验失败';
+    }
+
+    if (event.type === 'agent_step') {
+        return [event.thought, event.action].filter(Boolean).join('\n');
+    }
+
+    if (event.type === 'draft_ready') {
+        return event.proposal?.summary || 'Agent 已生成可预览的编辑草稿';
+    }
+
+    if (event.type === 'needs_confirmation') {
+        return '';
+    }
+
+    if (event.type === 'error') {
+        return event.error || event.message || '未知错误';
+    }
+
+    return event.message || event.summary || '';
+}
+
+function addAgentTimelineEvent(messageDiv, event) {
+    if (!messageDiv || !event) return;
+
+    let timeline = messageDiv.querySelector('.ai-agent-timeline');
+    if (!timeline) {
+        timeline = document.createElement('div');
+        timeline.className = 'ai-agent-timeline';
+        timeline.style.cssText = 'display:flex;flex-direction:column;gap:8px;margin-top:8px;';
+        const regenerateBtn = messageDiv.querySelector('.ai-answer-regenerate-btn');
+        messageDiv.insertBefore(timeline, regenerateBtn || null);
+    }
+
+    const item = document.createElement('div');
+    item.className = `ai-agent-event ai-agent-event-${event.type || 'unknown'}`;
+    item.style.cssText = 'border:1px solid #e5e7eb;border-radius:6px;padding:8px;background:#fff;font-size:13px;color:#374151;';
+
+    const title = document.createElement('div');
+    title.style.cssText = 'font-weight:600;margin-bottom:4px;color:#111827;';
+    title.textContent = getAgentEventLabel(event);
+
+    const detailText = compactAgentText(getAgentEventDetail(event), 700);
+    const detail = document.createElement('div');
+    detail.style.cssText = 'white-space:pre-wrap;line-height:1.4;color:#4b5563;';
+    detail.textContent = detailText;
+
+    item.appendChild(title);
+    if (detailText) {
+        item.appendChild(detail);
+    }
+    timeline.appendChild(item);
+
+    const messagesContainer = document.getElementById('aiChatMessages');
+    if (messagesContainer) {
+        messagesContainer.scrollTop = messagesContainer.scrollHeight;
+    }
+}
+
+function addAgentProposalControls(messageDiv, proposal) {
+    if (!messageDiv || !proposal || !proposal.htmlContent) return;
+    if (messageDiv.querySelector('.ai-agent-proposal-controls')) return;
+
+    const controls = document.createElement('div');
+    controls.className = 'ai-agent-proposal-controls';
+    controls.style.cssText = 'display:flex;gap:10px;align-items:center;margin-top:12px;padding-top:12px;border-top:1px solid #e5e7eb;flex-wrap:wrap;';
+
+    const previewBtn = document.createElement('button');
+    previewBtn.type = 'button';
+    previewBtn.className = 'ai-preview-changes-btn';
+    previewBtn.innerHTML = '<i class="fas fa-eye"></i> 预览';
+    previewBtn.style.cssText = 'background:#007bff;color:white;border:none;padding:8px 14px;border-radius:4px;cursor:pointer;font-size:14px;display:inline-flex;align-items:center;gap:6px;';
+    previewBtn.addEventListener('click', () => showHTMLPreview(proposal.htmlContent));
+
+    const applyBtn = document.createElement('button');
+    applyBtn.type = 'button';
+    applyBtn.className = 'ai-apply-changes-btn';
+    applyBtn.innerHTML = '<i class="fas fa-check"></i> 应用';
+    applyBtn.style.cssText = 'background:#28a745;color:white;border:none;padding:8px 14px;border-radius:4px;cursor:pointer;font-size:14px;display:inline-flex;align-items:center;gap:6px;';
+    applyBtn.disabled = proposal.validation && proposal.validation.valid === false;
+    if (applyBtn.disabled) {
+        applyBtn.style.background = '#6c757d';
+        applyBtn.style.cursor = 'not-allowed';
+        applyBtn.title = 'HTML 校验未通过，不能应用';
+    }
+    applyBtn.addEventListener('click', async () => {
+        applyBtn.disabled = true;
+        applyBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> 应用中...';
+        try {
+            await applyAgentProposal(proposal);
+            applyBtn.innerHTML = '<i class="fas fa-check-circle"></i> 已应用';
+            applyBtn.style.background = '#6c757d';
+            discardBtn.disabled = true;
+            discardBtn.style.cursor = 'not-allowed';
+        } catch (error) {
+            applyBtn.disabled = false;
+            applyBtn.innerHTML = '<i class="fas fa-exclamation-triangle"></i> 重试应用';
+            showNotification(`Agent 应用失败：${error.message || error}`, 'error');
+        }
+    });
+
+    const discardBtn = document.createElement('button');
+    discardBtn.type = 'button';
+    discardBtn.className = 'ai-preview-changes-btn';
+    discardBtn.innerHTML = '<i class="fas fa-times"></i> 放弃';
+    discardBtn.style.cssText = 'background:#6c757d;color:white;border:none;padding:8px 14px;border-radius:4px;cursor:pointer;font-size:14px;display:inline-flex;align-items:center;gap:6px;';
+    discardBtn.addEventListener('click', () => {
+        controls.remove();
+        showNotification('已放弃 Agent 草稿', 'info');
+    });
+
+    controls.appendChild(previewBtn);
+    controls.appendChild(applyBtn);
+    controls.appendChild(discardBtn);
+
+    const regenerateBtn = messageDiv.querySelector('.ai-answer-regenerate-btn');
+    messageDiv.insertBefore(controls, regenerateBtn || null);
+}
+
+async function handleAgentStreamingResponse(response, waitingDiv) {
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let aiMessageDiv = null;
+    let streamingMessageId = null;
+    let finalSummary = '';
+
+    const ensureMessage = () => {
+        if (aiMessageDiv) {
+            return aiMessageDiv;
+        }
+        removeWaitingAnimation();
+        streamingMessageId = 'ai-agent-message-' + Date.now();
+        aiMessageDiv = addAIMessage('Agent 正在编辑当前幻灯片', 'assistant', streamingMessageId);
+        aiMessageDiv.dataset.complete = 'false';
+        return aiMessageDiv;
+    };
+
+    const processLine = (line) => {
+        if (!line.trim().startsWith('data: ')) return;
+        const dataStr = line.slice(6).trim();
+        if (!dataStr) return;
+
+        let event;
+        try {
+            event = JSON.parse(dataStr);
+        } catch (error) {
+            return;
+        }
+        if (!event || event.type === '_agent_done') return;
+
+        const messageDiv = ensureMessage();
+        addAgentTimelineEvent(messageDiv, event);
+
+        if ((event.type === 'draft_ready' || event.type === 'final') && event.proposal) {
+            finalSummary = event.proposal.summary || 'Agent 已生成可预览的编辑草稿';
+            setAIAssistantMessageText(messageDiv, finalSummary);
+            addAgentProposalControls(messageDiv, event.proposal);
+        } else if (event.type === 'error') {
+            finalSummary = `抱歉，Agent 编辑失败：${event.error || event.message || '未知错误'}`;
+            setAIAssistantMessageText(messageDiv, finalSummary);
+        }
+    };
+
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop() || '';
+
+            for (const line of lines) {
+                processLine(line);
+            }
+        }
+
+        if (buffer.trim()) {
+            processLine(buffer);
+        }
+
+        if (!aiMessageDiv) {
+            removeWaitingAnimation();
+            finalSummary = 'Agent 没有返回可显示的结果';
+            aiMessageDiv = addAIMessage(finalSummary, 'assistant');
+        }
+    } catch (error) {
+        removeWaitingAnimation();
+        finalSummary = '抱歉，处理 Agent 流式响应时出现错误。';
+        if (aiMessageDiv) {
+            setAIAssistantMessageText(aiMessageDiv, finalSummary);
+        } else {
+            aiMessageDiv = addAIMessage(finalSummary, 'assistant');
+        }
+    } finally {
+        if (aiMessageDiv) {
+            aiMessageDiv.dataset.complete = 'true';
+            if (streamingMessageId && finalSummary) {
+                updateAIChatHistoryMessage(streamingMessageId, finalSummary);
+            }
+            refreshAIAssistantMessageLayout(aiMessageDiv);
+        }
+    }
+}
+
 // options:
 // - messageOverride: string (optional)
 // - appendUserMessage: boolean (default true)
@@ -652,7 +923,9 @@ async function sendAIMessage(options = {}) {
         const referencedImages = getAllUploadedImages();
 
         const context = {
+            projectId: window.landpptEditorConfig.projectId,
             slideIndex: currentSlideIndex + 1,
+            mode: 'slide',
             slideTitle: currentSlide.title,
             slideContent: currentSlide.html_content,
             userRequest: message,
@@ -671,7 +944,7 @@ async function sendAIMessage(options = {}) {
 
 
         // 发送流式AI编辑请求
-        const response = await fetch('/api/ai/slide-edit/stream', {
+        const response = await fetch('/api/ai/slide-edit-agent/stream', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -684,7 +957,7 @@ async function sendAIMessage(options = {}) {
         }
 
         // 处理流式响应
-        await handleStreamingResponse(response, waitingDiv);
+        await handleAgentStreamingResponse(response, waitingDiv);
 
     } catch (error) {
         removeWaitingAnimation();

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.quickAi.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.quickAi.js
@@ -760,6 +760,72 @@ function getCleanSlideHtmlForQuickAi() {
     return getCleanSlideHtmlForQuickEdit({ slideFrame });
 }
 
+async function computeQuickAiExpectedBaseHash(html) {
+    if (typeof crypto === 'undefined' || !crypto.subtle || typeof TextEncoder === 'undefined') {
+        return null;
+    }
+
+    const data = new TextEncoder().encode((html || '').trim());
+    const digest = await crypto.subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(digest))
+        .map(byte => byte.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+function getQuickAiElementDomPath(element) {
+    if (!element || !element.ownerDocument) return null;
+
+    const path = [];
+    let node = element;
+    const doc = element.ownerDocument;
+
+    while (node && node.nodeType === 1 && node !== doc.documentElement) {
+        const parent = node.parentElement;
+        if (!parent) break;
+
+        const tagName = node.tagName;
+        const siblings = Array.from(parent.children || []).filter(child => child.tagName === tagName);
+        path.unshift({
+            tagName,
+            index: siblings.indexOf(node)
+        });
+        node = parent;
+    }
+
+    return path.length ? path : null;
+}
+
+function findQuickAiElementByDomPath(doc, path) {
+    if (!doc || !Array.isArray(path) || path.length === 0) return null;
+
+    let node = doc.documentElement;
+    for (const step of path) {
+        if (!node || !step) return null;
+        const matches = Array.from(node.children || []).filter(child => child.tagName === step.tagName);
+        node = matches[step.index] || null;
+    }
+    return node;
+}
+
+function attachQuickAiIdToProposalHtml(htmlContent, elementId, elementPath) {
+    if (!htmlContent || !elementId || !elementPath) return htmlContent;
+
+    try {
+        const parsed = new DOMParser().parseFromString(String(htmlContent), 'text/html');
+        const existing = Array.from(parsed.querySelectorAll('[data-quick-ai-id]'))
+            .some(el => el.getAttribute('data-quick-ai-id') === elementId);
+        if (existing) return htmlContent;
+
+        const target = findQuickAiElementByDomPath(parsed, elementPath);
+        if (!target) return htmlContent;
+
+        target.setAttribute('data-quick-ai-id', elementId);
+        return parsed.documentElement?.outerHTML || htmlContent;
+    } catch (e) {
+        return htmlContent;
+    }
+}
+
 function parseQuickAiElementHtmlToIframeNode(elementHtml, iframeDoc, elementId) {
     if (!iframeDoc || !elementHtml) return null;
 
@@ -820,10 +886,10 @@ async function quickAiEditApply() {
         return;
     }
 
-    const iframeDoc = slideFrame.contentDocument;
     const currentSlide = (typeof slidesData !== 'undefined' && slidesData[currentSlideIndex]) ? slidesData[currentSlideIndex] : null;
 
     const elementId = ensureQuickAiElementId(selectedQuickEditElement);
+    const elementPath = getQuickAiElementDomPath(selectedQuickEditElement);
     quickAiTargetElementId = elementId;
 
     setQuickAiStatus('AI 正在处理…');
@@ -852,12 +918,21 @@ async function quickAiEditApply() {
         // 截图阶段结束后，恢复为“处理中”状态提示（避免一直停留在“截图中”）
         setQuickAiStatus('AI 正在处理…');
 
+        const slideContentForAgent = getCleanSlideHtmlForQuickAi() || currentSlide?.html_content || '';
+        const expectedBaseHtml = currentSlide?.html_content || getCleanSlideHtmlForQuickEdit({
+            slideFrame,
+            stripQuickAiIds: true
+        }) || '';
+        const expectedBaseHash = await computeQuickAiExpectedBaseHash(expectedBaseHtml);
+
         const payload = {
+            projectId: window.landpptEditorConfig.projectId,
             slideIndex: currentSlideIndex + 1,
+            mode: 'element',
             slideTitle: currentSlide?.title || '',
-            slideContent: getCleanSlideHtmlForQuickAi() || currentSlide?.html_content || '',
-            elementHtml: selectedQuickEditElement.outerHTML,
-            elementId: elementId,
+            slideContent: slideContentForAgent,
+            selectedElementHtml: selectedQuickEditElement.outerHTML,
+            selectedElementId: elementId,
             userRequest: userRequest,
             slideOutline: slideOutline,
             visionEnabled: visionEnabledForRequest,
@@ -870,7 +945,7 @@ async function quickAiEditApply() {
             }
         };
 
-        const response = await fetch('/api/ai/element-edit', {
+        const response = await fetch('/api/ai/slide-edit-agent/stream', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -878,46 +953,39 @@ async function quickAiEditApply() {
             body: JSON.stringify(payload)
         });
 
-        const result = await response.json().catch(() => ({}));
-        if (!response.ok || !result || !result.success) {
-            const message = (result && result.error) ? result.error : `请求失败：HTTP ${response.status}`;
-            throw new Error(message);
+        if (!response.ok) {
+            const message = await response.text().catch(() => '');
+            throw new Error(message || `请求失败：HTTP ${response.status}`);
         }
 
-        const updatedElementHtml = (result.updated_element_html || '').trim();
-        if (!updatedElementHtml) {
-            throw new Error('AI 未返回可用的元素 HTML');
+        const proposal = await collectAgentProposalFromStream(response, (event) => {
+            if (event.type === 'tool_call') {
+                setQuickAiStatus(`Agent调用工具：${event.tool || ''}`);
+            } else if (event.type === 'validation_result') {
+                setQuickAiStatus(event.valid ? '校验通过，准备应用…' : '校验失败');
+            }
+        });
+
+        if (proposal.validation && proposal.validation.valid === false) {
+            throw new Error((proposal.validation.errors || []).join('；') || 'Agent草稿校验失败');
+        }
+
+        proposal.htmlContent = attachQuickAiIdToProposalHtml(proposal.htmlContent, elementId, elementPath);
+
+        if (expectedBaseHash) {
+            proposal.baseHash = expectedBaseHash;
         }
 
         // 保存一次撤销点：在真正应用前
         saveStateForUndo();
-
-        const target = iframeDoc.querySelector(`[data-quick-ai-id="${elementId}"]`) || selectedQuickEditElement;
-        const newNode = parseQuickAiElementHtmlToIframeNode(updatedElementHtml, iframeDoc, elementId);
-        if (!target || !newNode) {
-            throw new Error('无法解析或定位要替换的元素');
-        }
-
-        target.replaceWith(newNode);
+        await applyAgentProposal(proposal);
 
         // 重新绑定快速编辑事件到新元素（允许对新增元素补绑定）
         initQuickEditElementSelection();
-
-        // 重新选中，恢复手柄/拖拽等能力
-        selectQuickEditElement(newNode, { allowWhileAiSending: true });
-
-        // 保存并同步到缩略图/服务端
-        saveQuickEditChanges();
-
-        showToolbarStatus('AI 已应用到选中元素', 'success');
+        syncQuickElementAgentResult(currentSlideIndex, proposal.htmlContent, elementId);
+        showToolbarStatus('Agent 已应用到选中元素', 'success');
         setQuickAiStatus('已应用，继续输入可再次编辑');
 
-        // 清理定位属性，避免长期残留在 iframe DOM 中
-        try {
-            if (selectedQuickEditElement) {
-                selectedQuickEditElement.removeAttribute('data-quick-ai-id');
-            }
-        } catch (e) { }
         quickAiTargetElementId = null;
 
         // 清空输入，便于下一次操作

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.quickAi.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.quickAi.js
@@ -807,25 +807,6 @@ function findQuickAiElementByDomPath(doc, path) {
     return node;
 }
 
-function attachQuickAiIdToProposalHtml(htmlContent, elementId, elementPath) {
-    if (!htmlContent || !elementId || !elementPath) return htmlContent;
-
-    try {
-        const parsed = new DOMParser().parseFromString(String(htmlContent), 'text/html');
-        const existing = Array.from(parsed.querySelectorAll('[data-quick-ai-id]'))
-            .some(el => el.getAttribute('data-quick-ai-id') === elementId);
-        if (existing) return htmlContent;
-
-        const target = findQuickAiElementByDomPath(parsed, elementPath);
-        if (!target) return htmlContent;
-
-        target.setAttribute('data-quick-ai-id', elementId);
-        return parsed.documentElement?.outerHTML || htmlContent;
-    } catch (e) {
-        return htmlContent;
-    }
-}
-
 function parseQuickAiElementHtmlToIframeNode(elementHtml, iframeDoc, elementId) {
     if (!iframeDoc || !elementHtml) return null;
 
@@ -960,7 +941,7 @@ async function quickAiEditApply() {
 
         const proposal = await collectAgentProposalFromStream(response, (event) => {
             if (event.type === 'tool_call') {
-                setQuickAiStatus(`Agent调用工具：${event.tool || ''}`);
+                setQuickAiStatus(`Agent 调用工具：${event.tool || ''}`);
             } else if (event.type === 'validation_result') {
                 setQuickAiStatus(event.valid ? '校验通过，准备应用…' : '校验失败');
             }
@@ -970,19 +951,22 @@ async function quickAiEditApply() {
             throw new Error((proposal.validation.errors || []).join('；') || 'Agent草稿校验失败');
         }
 
-        proposal.htmlContent = attachQuickAiIdToProposalHtml(proposal.htmlContent, elementId, elementPath);
-
-        if (expectedBaseHash) {
-            proposal.baseHash = expectedBaseHash;
-        }
+        const applyProposal = expectedBaseHash
+            ? { ...proposal, baseHash: expectedBaseHash }
+            : { ...proposal };
 
         // 保存一次撤销点：在真正应用前
         saveStateForUndo();
-        await applyAgentProposal(proposal);
+        const applied = await applyAgentProposal(applyProposal);
 
         // 重新绑定快速编辑事件到新元素（允许对新增元素补绑定）
         initQuickEditElementSelection();
-        syncQuickElementAgentResult(currentSlideIndex, proposal.htmlContent, elementId);
+        syncQuickElementAgentResult(
+            currentSlideIndex,
+            applied.htmlContent || applyProposal.htmlContent,
+            elementId,
+            elementPath
+        );
         showToolbarStatus('Agent 已应用到选中元素', 'success');
         setQuickAiStatus('已应用，继续输入可再次编辑');
 

--- a/src/landppt/web/templates/pages/project/project_slides_editor.html
+++ b/src/landppt/web/templates/pages/project/project_slides_editor.html
@@ -742,8 +742,8 @@
     <script src="/static/js/pages/project/slides_editor/projectSlidesEditor.slideMediaUi.js?v=20260402-split"></script>
     <script src="/static/js/pages/project/slides_editor/projectSlidesEditor.pretextBridge.js?v=20260406-pretext"></script>
     <script src="/static/js/pages/project/slides_editor/projectSlidesEditor.nativeChat.js?v=20260402-split"></script>
-    <script src="/static/js/pages/project/slides_editor/projectSlidesEditor.aiChat.js?v=20260614-modalui"></script>
-    <script src="/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js?v=20260402-split"></script>
+    <script src="/static/js/pages/project/slides_editor/projectSlidesEditor.aiChat.js?v=20260705-agent-stream"></script>
+    <script src="/static/js/pages/project/slides_editor/projectSlidesEditor.aiApply.js?v=20260705-agent-apply"></script>
     <script src="/static/js/pages/project/slides_editor/projectSlidesEditor.slideGeneration.js?v=20260408-quick-reset-v2"></script>
     <script src="/static/js/pages/project/slides_editor/projectSlidesEditor.changeTemplate.js?v=20260408-free-template-list-v2"></script>
     <script src="/static/js/pages/project/slides_editor/projectSlidesEditor.slideshow.js?v=20260402-split"></script>

--- a/tests/test_export_support_models.py
+++ b/tests/test_export_support_models.py
@@ -1,8 +1,11 @@
 import importlib.util
+import io
 import logging
 import sys
 import types
+import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -85,3 +88,51 @@ def test_image_pptx_export_request_validates_after_model_rebuild():
     assert payload.slides[0]["index"] == 1
     assert payload.images is not None
     assert payload.images[0]["width"] == 1280
+
+
+def test_html_zip_export_keeps_interactive_slide_html_without_duplicate_viewers():
+    module = _load_export_support_module()
+    project = SimpleNamespace(
+        topic="Demo Deck",
+        slides_data=[
+            {
+                "title": "Interactive",
+                "html_content": """
+<!DOCTYPE html>
+<html>
+<head><title>Interactive</title></head>
+<body>
+    <a id="externalLink" href="https://example.com/path">Open</a>
+    <button id="runButton" onclick="window.clicked = true">Run</button>
+    <script>window.loaded = true;</script>
+</body>
+</html>
+""",
+            },
+            {
+                "title": "Second",
+                "html_content": "<main><button onclick=\"window.second = true\">Second</button></main>",
+            },
+        ],
+    )
+
+    zip_bytes = module._generate_html_export_sync(project, "http://localhost:8000")
+
+    with zipfile.ZipFile(io.BytesIO(zip_bytes), "r") as archive:
+        names = archive.namelist()
+        assert names == ["index.html", "slides/slide_1.html", "slides/slide_2.html"]
+        assert "slide_1.html" not in names
+        assert names.count("slides/slide_1.html") == 1
+
+        index_html = archive.read("index.html").decode("utf-8")
+        assert 'src="slides/slide_1.html"' in index_html
+        assert ".stage-shield" in index_html
+        assert "pointer-events: none" in index_html
+
+        first_slide = archive.read("slides/slide_1.html").decode("utf-8")
+        assert 'href="https://example.com/path"' in first_slide
+        assert 'onclick="window.clicked = true"' in first_slide
+        assert "<script>window.loaded = true;</script>" in first_slide
+
+        second_slide = archive.read("slides/slide_2.html").decode("utf-8")
+        assert 'onclick="window.second = true"' in second_slide

--- a/tests/test_slide_edit_agent_routes.py
+++ b/tests/test_slide_edit_agent_routes.py
@@ -163,8 +163,37 @@ async def test_apply_agent_proposal_strips_agent_ids_before_save(monkeypatch):
     assert "New" in saved_html
 
 
+@pytest.mark.parametrize(
+    ("html_content", "expected_error"),
+    [
+        (
+            '<div style="width:1280px;height:720px">'
+            "<script>alert(1)</script><h1>New</h1></div>",
+            "script tags are not allowed",
+        ),
+        (
+            '<div style="width:1280px;height:720px">'
+            '<h1 onclick="bad()">New</h1></div>',
+            "inline event handlers are not allowed",
+        ),
+        (
+            '<div style="width:1280px;height:720px">'
+            '<a href="java&#115;cript:bad()">New</a></div>',
+            "javascript urls are not allowed",
+        ),
+        ("", "html content is required"),
+        (
+            '<div style="width:1280px;height:720px"><section><h1>New</section></div>',
+            "html is malformed",
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_apply_agent_proposal_rejects_invalid_html(monkeypatch):
+async def test_apply_agent_proposal_rejects_invalid_html_before_save(
+    monkeypatch,
+    html_content,
+    expected_error,
+):
     current_html = '<div style="width:1280px;height:720px"><h1>Current</h1></div>'
     project = SimpleNamespace(
         slides_data=[
@@ -186,10 +215,7 @@ async def test_apply_agent_proposal_rejects_invalid_html(monkeypatch):
         projectId="proj",
         slideIndex=1,
         expectedBaseHash=compute_slide_html_hash(current_html),
-        htmlContent=(
-            '<div style="width:1280px;height:720px">'
-            "<script>alert(1)</script><h1>New</h1></div>"
-        ),
+        htmlContent=html_content,
         slideData={"title": "One"},
     )
 
@@ -199,7 +225,7 @@ async def test_apply_agent_proposal_rejects_invalid_html(monkeypatch):
         )
 
     assert exc.value.status_code == 400
-    assert "script tags are not allowed" in exc.value.detail["errors"]
+    assert expected_error in exc.value.detail["errors"]
 
 
 @pytest.mark.asyncio
@@ -212,6 +238,7 @@ async def test_stream_slide_edit_agent_charges_once_after_draft(monkeypatch):
             await event_callback(
                 {"type": "draft_ready", "proposal": {"proposalId": "p1"}}
             )
+            await event_callback({"type": "final", "proposalId": "p1"})
             await event_callback({"type": "needs_confirmation", "proposalId": "p1"})
             return SimpleNamespace(proposal_id="p1")
 
@@ -246,6 +273,52 @@ async def test_stream_slide_edit_agent_charges_once_after_draft(monkeypatch):
     assert len(charges) == 1
     assert charges[0]["args"][:3] == (10, "ai_edit", 1)
     assert charges[0]["kwargs"]["reference_id"] == "proj"
+
+
+@pytest.mark.asyncio
+async def test_stream_slide_edit_agent_charges_before_billable_chunk(monkeypatch):
+    charges = []
+
+    class _FakeAgentService:
+        async def run_agent(self, request, user_ppt_service, event_callback):
+            await event_callback(
+                {"type": "draft_ready", "proposal": {"proposalId": "p1"}}
+            )
+            return SimpleNamespace(proposal_id="p1")
+
+    async def check_credits(*args, **kwargs):
+        return True, 1, 10
+
+    async def consume_credits(*args, **kwargs):
+        charges.append({"args": args, "kwargs": kwargs})
+        return True, "ok"
+
+    monkeypatch.setattr(
+        routes, "get_ppt_service_for_user", lambda user_id: _FakePPTService()
+    )
+    monkeypatch.setattr(routes, "check_credits_for_operation", check_credits)
+    monkeypatch.setattr(routes, "consume_credits_for_operation", consume_credits)
+    monkeypatch.setattr(routes, "SlideEditAgentService", _FakeAgentService)
+
+    response = await routes.stream_slide_edit_agent(
+        SlideEditAgentRequest(
+            projectId="proj",
+            slideIndex=1,
+            slideTitle="One",
+            slideContent="<div>Current</div>",
+            userRequest="Shorten the title",
+        ),
+        user=SimpleNamespace(id=10),
+    )
+
+    first_chunk = await anext(response.body_iterator)
+    if isinstance(first_chunk, bytes):
+        first_chunk = first_chunk.decode("utf-8")
+
+    assert '"type": "draft_ready"' in first_chunk
+    assert len(charges) == 1
+
+    await _collect_stream_body(response)
 
 
 @pytest.mark.asyncio

--- a/tests/test_slide_edit_agent_routes.py
+++ b/tests/test_slide_edit_agent_routes.py
@@ -20,11 +20,14 @@ class _FakeProjectManager:
 
 
 class _FakePPTService:
-    def __init__(self, project=None):
+    def __init__(self, project=None, providers=None):
         self.project_manager = _FakeProjectManager(project)
+        self.providers = providers or {}
+        self.roles = []
 
     async def get_role_provider_async(self, role):
-        return None, {"provider": "landppt"}
+        self.roles.append(role)
+        return None, {"provider": self.providers.get(role, "landppt")}
 
 
 async def _collect_stream_body(response):
@@ -117,6 +120,89 @@ async def test_apply_agent_proposal_saves_only_target_slide(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_apply_agent_proposal_strips_agent_ids_before_save(monkeypatch):
+    current_html = '<div style="width:1280px;height:720px"><h1>Current</h1></div>'
+    project = SimpleNamespace(
+        slides_data=[
+            {"title": "One", "html_content": current_html, "is_user_edited": False}
+        ]
+    )
+    saved = {}
+
+    class _FakeDBManager:
+        async def save_single_slide(self, project_id, slide_index, slide_data):
+            saved["slide_data"] = slide_data
+            return True
+
+    monkeypatch.setattr(
+        routes, "get_ppt_service_for_user", lambda user_id: _FakePPTService(project)
+    )
+    monkeypatch.setattr(routes, "DatabaseProjectManager", lambda: _FakeDBManager())
+
+    request = SlideEditAgentApplyRequest(
+        proposalId="p1",
+        projectId="proj",
+        slideIndex=1,
+        expectedBaseHash=compute_slide_html_hash(current_html),
+        htmlContent=(
+            '<div data-agent-id="a1" data-quick-ai-id="q1" '
+            'style="width:1280px;height:720px">'
+            '<h1 data-quick-ai-id="q2">New</h1></div>'
+        ),
+        slideData={"title": "One"},
+    )
+
+    result = await routes.apply_slide_edit_agent_proposal(
+        request, user=SimpleNamespace(id=10)
+    )
+
+    saved_html = saved["slide_data"]["html_content"]
+    assert result["htmlContent"] == saved_html
+    assert "data-agent-id" not in saved_html
+    assert "data-quick-ai-id" not in saved_html
+    assert "New" in saved_html
+
+
+@pytest.mark.asyncio
+async def test_apply_agent_proposal_rejects_invalid_html(monkeypatch):
+    current_html = '<div style="width:1280px;height:720px"><h1>Current</h1></div>'
+    project = SimpleNamespace(
+        slides_data=[
+            {"title": "One", "html_content": current_html, "is_user_edited": False}
+        ]
+    )
+
+    class _FakeDBManager:
+        async def save_single_slide(self, project_id, slide_index, slide_data):
+            raise AssertionError("invalid HTML should not be saved")
+
+    monkeypatch.setattr(
+        routes, "get_ppt_service_for_user", lambda user_id: _FakePPTService(project)
+    )
+    monkeypatch.setattr(routes, "DatabaseProjectManager", lambda: _FakeDBManager())
+
+    request = SlideEditAgentApplyRequest(
+        proposalId="p1",
+        projectId="proj",
+        slideIndex=1,
+        expectedBaseHash=compute_slide_html_hash(current_html),
+        htmlContent=(
+            '<div style="width:1280px;height:720px">'
+            "<script>alert(1)</script><h1>New</h1></div>"
+        ),
+        slideData={"title": "One"},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await routes.apply_slide_edit_agent_proposal(
+            request, user=SimpleNamespace(id=10)
+        )
+
+    assert exc.value.status_code == 400
+    assert "script tags are not allowed" in exc.value.detail["errors"]
+
+
+@pytest.mark.asyncio
 async def test_stream_slide_edit_agent_charges_once_after_draft(monkeypatch):
     charges = []
 
@@ -160,6 +246,58 @@ async def test_stream_slide_edit_agent_charges_once_after_draft(monkeypatch):
     assert len(charges) == 1
     assert charges[0]["args"][:3] == (10, "ai_edit", 1)
     assert charges[0]["kwargs"]["reference_id"] == "proj"
+
+
+@pytest.mark.asyncio
+async def test_stream_slide_edit_agent_uses_editor_provider_without_vision_inputs(
+    monkeypatch,
+):
+    service = _FakePPTService(
+        providers={
+            "editor": "editor-provider",
+            "vision_analysis": "vision-provider",
+        }
+    )
+    check_provider_names = []
+    charge_provider_names = []
+
+    class _FakeAgentService:
+        async def run_agent(self, request, user_ppt_service, event_callback):
+            await event_callback(
+                {"type": "draft_ready", "proposal": {"proposalId": "p1"}}
+            )
+            return SimpleNamespace(proposal_id="p1")
+
+    async def check_credits(*args, **kwargs):
+        check_provider_names.append(kwargs.get("provider_name"))
+        return True, 1, 10
+
+    async def consume_credits(*args, **kwargs):
+        charge_provider_names.append(kwargs.get("provider_name"))
+        return True, "ok"
+
+    monkeypatch.setattr(routes, "get_ppt_service_for_user", lambda user_id: service)
+    monkeypatch.setattr(routes, "check_credits_for_operation", check_credits)
+    monkeypatch.setattr(routes, "consume_credits_for_operation", consume_credits)
+    monkeypatch.setattr(routes, "SlideEditAgentService", _FakeAgentService)
+
+    response = await routes.stream_slide_edit_agent(
+        SlideEditAgentRequest(
+            projectId="proj",
+            slideIndex=1,
+            slideContent="<div>Current</div>",
+            userRequest="Shorten the title",
+            visionEnabled=True,
+        ),
+        user=SimpleNamespace(id=10),
+    )
+
+    body = await _collect_stream_body(response)
+
+    assert '"type": "draft_ready"' in body
+    assert service.roles == ["editor"]
+    assert check_provider_names == ["editor-provider"]
+    assert charge_provider_names == ["editor-provider"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_slide_edit_agent_routes.py
+++ b/tests/test_slide_edit_agent_routes.py
@@ -1,0 +1,209 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from landppt.services.slide.slide_edit_agent_service import (
+    SlideEditAgentApplyRequest,
+    SlideEditAgentRequest,
+    compute_slide_html_hash,
+)
+from landppt.web.route_modules import slide_edit_agent_routes as routes
+
+
+class _FakeProjectManager:
+    def __init__(self, project):
+        self.project = project
+
+    async def get_project(self, project_id, user_id=None):
+        return self.project
+
+
+class _FakePPTService:
+    def __init__(self, project=None):
+        self.project_manager = _FakeProjectManager(project)
+
+    async def get_role_provider_async(self, role):
+        return None, {"provider": "landppt"}
+
+
+async def _collect_stream_body(response):
+    chunks = []
+    async for chunk in response.body_iterator:
+        if isinstance(chunk, bytes):
+            chunk = chunk.decode("utf-8")
+        chunks.append(chunk)
+    return "".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_apply_agent_proposal_rejects_base_hash_mismatch(monkeypatch):
+    project = SimpleNamespace(
+        slides_data=[
+            {
+                "title": "One",
+                "html_content": "<div>Current</div>",
+                "is_user_edited": False,
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        routes, "get_ppt_service_for_user", lambda user_id: _FakePPTService(project)
+    )
+
+    request = SlideEditAgentApplyRequest(
+        proposalId="p1",
+        projectId="proj",
+        slideIndex=1,
+        expectedBaseHash=compute_slide_html_hash("<div>Old</div>"),
+        htmlContent="<div>New</div>",
+        slideData={"title": "One"},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await routes.apply_slide_edit_agent_proposal(
+            request, user=SimpleNamespace(id=10)
+        )
+
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_apply_agent_proposal_saves_only_target_slide(monkeypatch):
+    current_html = '<div style="width:1280px;height:720px"><h1>Current</h1></div>'
+    project = SimpleNamespace(
+        slides_data=[
+            {"title": "One", "html_content": current_html, "is_user_edited": False},
+            {
+                "title": "Two",
+                "html_content": "<div>Second</div>",
+                "is_user_edited": False,
+            },
+        ]
+    )
+    saved = {}
+
+    class _FakeDBManager:
+        async def save_single_slide(self, project_id, slide_index, slide_data):
+            saved["project_id"] = project_id
+            saved["slide_index"] = slide_index
+            saved["slide_data"] = slide_data
+            return True
+
+    monkeypatch.setattr(
+        routes, "get_ppt_service_for_user", lambda user_id: _FakePPTService(project)
+    )
+    monkeypatch.setattr(routes, "DatabaseProjectManager", lambda: _FakeDBManager())
+
+    request = SlideEditAgentApplyRequest(
+        proposalId="p1",
+        projectId="proj",
+        slideIndex=1,
+        expectedBaseHash=compute_slide_html_hash(current_html),
+        htmlContent='<div style="width:1280px;height:720px"><h1>New</h1></div>',
+        slideData={"title": "One"},
+    )
+
+    result = await routes.apply_slide_edit_agent_proposal(
+        request, user=SimpleNamespace(id=10)
+    )
+
+    assert result["success"] is True
+    assert saved["project_id"] == "proj"
+    assert saved["slide_index"] == 0
+    assert saved["slide_data"]["title"] == "One"
+    assert "New" in saved["slide_data"]["html_content"]
+    assert saved["slide_data"]["is_user_edited"] is True
+
+
+@pytest.mark.asyncio
+async def test_stream_slide_edit_agent_charges_once_after_draft(monkeypatch):
+    charges = []
+
+    class _FakeAgentService:
+        async def run_agent(self, request, user_ppt_service, event_callback):
+            await event_callback({"type": "agent_start"})
+            await event_callback(
+                {"type": "draft_ready", "proposal": {"proposalId": "p1"}}
+            )
+            await event_callback({"type": "needs_confirmation", "proposalId": "p1"})
+            return SimpleNamespace(proposal_id="p1")
+
+    async def check_credits(*args, **kwargs):
+        return True, 1, 10
+
+    async def consume_credits(*args, **kwargs):
+        charges.append({"args": args, "kwargs": kwargs})
+        return True, "ok"
+
+    monkeypatch.setattr(
+        routes, "get_ppt_service_for_user", lambda user_id: _FakePPTService()
+    )
+    monkeypatch.setattr(routes, "check_credits_for_operation", check_credits)
+    monkeypatch.setattr(routes, "consume_credits_for_operation", consume_credits)
+    monkeypatch.setattr(routes, "SlideEditAgentService", _FakeAgentService)
+
+    response = await routes.stream_slide_edit_agent(
+        SlideEditAgentRequest(
+            projectId="proj",
+            slideIndex=1,
+            slideTitle="One",
+            slideContent="<div>Current</div>",
+            userRequest="Shorten the title",
+        ),
+        user=SimpleNamespace(id=10),
+    )
+
+    body = await _collect_stream_body(response)
+
+    assert '"type": "draft_ready"' in body
+    assert len(charges) == 1
+    assert charges[0]["args"][:3] == (10, "ai_edit", 1)
+    assert charges[0]["kwargs"]["reference_id"] == "proj"
+
+
+@pytest.mark.asyncio
+async def test_stream_slide_edit_agent_does_not_charge_without_draft(monkeypatch):
+    charges = []
+
+    class _FakeAgentService:
+        async def run_agent(self, request, user_ppt_service, event_callback):
+            await event_callback({"type": "agent_start"})
+            raise RuntimeError("model unavailable")
+
+    async def check_credits(*args, **kwargs):
+        return True, 1, 10
+
+    async def consume_credits(*args, **kwargs):
+        charges.append({"args": args, "kwargs": kwargs})
+        return True, "ok"
+
+    monkeypatch.setattr(
+        routes, "get_ppt_service_for_user", lambda user_id: _FakePPTService()
+    )
+    monkeypatch.setattr(routes, "check_credits_for_operation", check_credits)
+    monkeypatch.setattr(routes, "consume_credits_for_operation", consume_credits)
+    monkeypatch.setattr(routes, "SlideEditAgentService", _FakeAgentService)
+
+    response = await routes.stream_slide_edit_agent(
+        SlideEditAgentRequest(
+            projectId="proj",
+            slideIndex=1,
+            slideContent="<div>Current</div>",
+            userRequest="Shorten the title",
+        ),
+        user=SimpleNamespace(id=10),
+    )
+
+    body = await _collect_stream_body(response)
+
+    assert '"type": "error"' in body
+    assert "model unavailable" in body
+    assert charges == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_slide_edit_agent_returns_success():
+    result = await routes.cancel_slide_edit_agent(user=SimpleNamespace(id=10))
+
+    assert result == {"success": True}

--- a/tests/test_slide_edit_agent_service.py
+++ b/tests/test_slide_edit_agent_service.py
@@ -223,6 +223,32 @@ async def test_tool_runner_replace_element_missing_id_fails_without_mutating_dra
 
 
 @pytest.mark.asyncio
+async def test_tool_runner_update_text_missing_target_fails_without_mutating_draft():
+    runner = SlideEditToolRunner(_tool_context())
+    original_html = runner.current_html
+
+    result = await runner.execute_tool("update_text", {"text": "Short Title"})
+
+    assert result["success"] is False
+    assert result["tool"] == "update_text"
+    assert "requires" in result["error"]
+    assert runner.current_html == original_html
+
+
+@pytest.mark.asyncio
+async def test_tool_runner_delete_element_missing_target_fails_without_mutating_draft():
+    runner = SlideEditToolRunner(_tool_context())
+    original_html = runner.current_html
+
+    result = await runner.execute_tool("delete_element", {})
+
+    assert result["success"] is False
+    assert result["tool"] == "delete_element"
+    assert "requires" in result["error"]
+    assert runner.current_html == original_html
+
+
+@pytest.mark.asyncio
 async def test_tool_runner_replace_element_rejects_unsafe_fragment_without_mutating_draft():
     runner = SlideEditToolRunner(
         _tool_context(

--- a/tests/test_slide_edit_agent_service.py
+++ b/tests/test_slide_edit_agent_service.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from landppt.ai.base import ImageContent, TextContent
 from landppt.services.slide.slide_edit_agent_service import (
     SlideEditAgentContext,
     SlideEditAgentRequest,
@@ -363,6 +364,11 @@ class _FakePPTService:
         return SimpleNamespace(content=self.responses.pop(0))
 
 
+class _FailingPPTService:
+    async def _chat_completion_for_role(self, role, messages):
+        raise RuntimeError("model unavailable")
+
+
 @pytest.mark.asyncio
 async def test_slide_edit_agent_runs_tools_and_returns_proposal():
     service = SlideEditAgentService()
@@ -471,3 +477,118 @@ async def test_slide_edit_agent_finalizes_when_max_iterations_is_reached():
         == "Reached the maximum edit iterations and prepared the current draft."
     )
     assert proposal.validation.valid is True
+
+
+@pytest.mark.asyncio
+async def test_slide_edit_agent_emits_error_event_when_model_fails():
+    service = SlideEditAgentService()
+    events = []
+
+    async def capture(event):
+        events.append(event)
+
+    with pytest.raises(RuntimeError, match="model unavailable"):
+        await service.run_agent(_tool_request(), _FailingPPTService(), capture)
+
+    error_events = [event for event in events if event["type"] == "error"]
+    assert error_events == [
+        {
+            "type": "error",
+            "phase": "model",
+            "message": "model unavailable",
+            "errorType": "RuntimeError",
+            "iteration": 1,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_slide_edit_agent_emits_error_event_when_tool_raises(monkeypatch):
+    service = SlideEditAgentService()
+    fake_ppt = _FakePPTService(
+        [
+            json.dumps(
+                {
+                    "thought": "Try to inspect.",
+                    "action": "inspect_slide_html",
+                    "action_input": {},
+                }
+            )
+        ]
+    )
+    events = []
+
+    async def capture(event):
+        events.append(event)
+
+    async def fail_tool(self, tool_name, tool_input):
+        raise ValueError("tool exploded")
+
+    monkeypatch.setattr(SlideEditToolRunner, "execute_tool", fail_tool)
+
+    with pytest.raises(ValueError, match="tool exploded"):
+        await service.run_agent(_tool_request(), fake_ppt, capture)
+
+    error_events = [event for event in events if event["type"] == "error"]
+    assert error_events == [
+        {
+            "type": "error",
+            "phase": "tool",
+            "message": "tool exploded",
+            "errorType": "ValueError",
+            "iteration": 1,
+            "tool": "inspect_slide_html",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_slide_edit_agent_vision_mode_sends_multimodal_context():
+    service = SlideEditAgentService()
+    screenshot = "data:image/png;base64,slide-shot"
+    reference_url = "https://example.test/reference.png"
+    fake_ppt = _FakePPTService(
+        [
+            json.dumps(
+                {
+                    "thought": "Vision context is enough.",
+                    "action": "final",
+                    "action_input": {"summary": "Checked visual context."},
+                }
+            )
+        ]
+    )
+
+    proposal = await service.run_agent(
+        _tool_request(
+            visionEnabled=True,
+            slideScreenshot=screenshot,
+            images=[{"name": "Reference", "size": "120KB", "url": reference_url}],
+        ),
+        fake_ppt,
+    )
+
+    assert proposal.summary == "Checked visual context."
+    role, messages = fake_ppt.calls[0]
+    assert role == "vision_analysis"
+    user_content = messages[-1].content
+    assert isinstance(user_content, list)
+    assert isinstance(user_content[0], TextContent)
+    assert '"vision"' in user_content[0].text
+    assert "slide_screenshot" in user_content[0].text
+    assert "Reference" in user_content[0].text
+    assert screenshot not in user_content[0].text
+    image_parts = [part for part in user_content if isinstance(part, ImageContent)]
+    assert [part.image_url["url"] for part in image_parts] == [
+        screenshot,
+        reference_url,
+    ]
+
+
+def test_slide_edit_agent_tool_schemas_match_runner_tool_names():
+    service = SlideEditAgentService()
+    runner = SlideEditToolRunner(_tool_context())
+
+    schema_names = [schema["name"] for schema in service._tool_schemas(runner)]
+
+    assert schema_names == runner.available_tool_names()

--- a/tests/test_slide_edit_agent_service.py
+++ b/tests/test_slide_edit_agent_service.py
@@ -1,0 +1,81 @@
+import asyncio
+import json
+
+from landppt.services.slide.slide_edit_agent_service import (
+    compute_slide_html_hash,
+    coerce_agent_max_iterations,
+    parse_agent_action,
+    sanitize_slide_html,
+    strip_agent_ids,
+    validate_slide_html,
+)
+
+
+def test_parse_agent_action_supports_json_code_fence():
+    action = parse_agent_action(
+        "```json\n"
+        + json.dumps(
+            {
+                "thought": "Inspect the slide before editing.",
+                "action": "inspect_slide_html",
+                "action_input": {"slide_index": 1},
+            }
+        )
+        + "\n```"
+    )
+
+    assert action.thought == "Inspect the slide before editing."
+    assert action.action == "inspect_slide_html"
+    assert action.action_input == {"slide_index": 1}
+
+
+def test_parse_agent_action_falls_back_to_final_for_unparseable_text():
+    action = parse_agent_action("I cannot parse this as JSON.")
+
+    assert action.action == "final"
+    assert action.action_input["summary"] == "I cannot parse this as JSON."
+
+
+def test_coerce_agent_max_iterations_defaults_and_clamps():
+    assert coerce_agent_max_iterations(None) == 6
+    assert coerce_agent_max_iterations(1) == 2
+    assert coerce_agent_max_iterations(8) == 8
+    assert coerce_agent_max_iterations(99) == 12
+    assert coerce_agent_max_iterations("bad") == 6
+
+
+def test_compute_slide_html_hash_is_stable_for_equivalent_text():
+    assert compute_slide_html_hash(" <div>A</div>\n") == compute_slide_html_hash("<div>A</div>")
+    assert compute_slide_html_hash("<div>A</div>") != compute_slide_html_hash("<div>B</div>")
+
+
+def test_sanitize_slide_html_removes_scripts_event_handlers_and_agent_ids():
+    html = (
+        '<div data-agent-id="a1" onclick="bad()" style="width:1280px;height:720px">'
+        '<a href="javascript:bad()">x</a><script>alert(1)</script>'
+        "</div>"
+    )
+
+    sanitized = sanitize_slide_html(html)
+
+    assert "<script" not in sanitized.lower()
+    assert "onclick" not in sanitized.lower()
+    assert "javascript:" not in sanitized.lower()
+    assert "data-agent-id" not in strip_agent_ids(sanitized)
+
+
+def test_validate_slide_html_reports_unsafe_original_html():
+    result = validate_slide_html('<div><script>alert(1)</script><p onclick="x()">Hi</p></div>')
+
+    assert result.valid is False
+    assert "script tags are not allowed" in result.errors
+    assert "inline event handlers are not allowed" in result.errors
+    assert "<script" not in result.sanitized_html.lower()
+
+
+def test_validate_slide_html_accepts_clean_slide_html():
+    result = validate_slide_html('<div style="width:1280px;height:720px"><h1>Hello</h1></div>')
+
+    assert result.valid is True
+    assert result.errors == []
+    assert "Hello" in result.sanitized_html

--- a/tests/test_slide_edit_agent_service.py
+++ b/tests/test_slide_edit_agent_service.py
@@ -1,6 +1,11 @@
 import json
 
+import pytest
+
 from landppt.services.slide.slide_edit_agent_service import (
+    SlideEditAgentContext,
+    SlideEditAgentRequest,
+    SlideEditToolRunner,
     compute_slide_html_hash,
     coerce_agent_max_iterations,
     parse_agent_action,
@@ -86,3 +91,121 @@ def test_validate_slide_html_accepts_clean_slide_html():
     assert result.valid is True
     assert result.errors == []
     assert "Hello" in result.sanitized_html
+
+
+def _tool_request(**overrides):
+    data = {
+        "projectId": "p1",
+        "slideIndex": 1,
+        "userRequest": "Make the title shorter",
+        "slideTitle": "Original",
+        "slideContent": '<div style="width:1280px;height:720px"><h1>Long Original Title</h1><p>Body</p></div>',
+        "projectInfo": {"title": "Project", "topic": "Topic", "scenario": "Pitch"},
+        "slideOutline": {"title": "Original", "content_points": ["Body"]},
+    }
+    data.update(overrides)
+    return SlideEditAgentRequest(**data)
+
+
+def _tool_context(**overrides):
+    request = _tool_request(**overrides)
+    return SlideEditAgentContext.from_request(request)
+
+
+@pytest.mark.asyncio
+async def test_tool_runner_inspects_slide_html():
+    runner = SlideEditToolRunner(_tool_context())
+
+    result = await runner.execute_tool("inspect_slide_html", {"slide_index": 1})
+
+    assert result["success"] is True
+    assert result["tool"] == "inspect_slide_html"
+    assert result["headings"][0]["text"] == "Long Original Title"
+    assert result["text_blocks"]
+
+
+@pytest.mark.asyncio
+async def test_tool_runner_replace_slide_html_updates_draft_not_base():
+    context = _tool_context()
+    runner = SlideEditToolRunner(context)
+    original_hash = context.base_hash
+
+    result = await runner.execute_tool(
+        "replace_slide_html",
+        {"html": '<div style="width:1280px;height:720px"><h1>New</h1></div>'},
+    )
+
+    assert result["success"] is True
+    assert "New" in runner.current_html
+    assert context.base_hash == original_hash
+    assert "Long Original Title" in context.base_html
+
+
+@pytest.mark.asyncio
+async def test_tool_runner_updates_text_by_selector():
+    runner = SlideEditToolRunner(_tool_context())
+
+    result = await runner.execute_tool("update_text", {"selector": "h1", "text": "Short Title"})
+
+    assert result["success"] is True
+    assert "Short Title" in runner.current_html
+    assert "Long Original Title" not in runner.current_html
+
+
+@pytest.mark.asyncio
+async def test_tool_runner_update_style_uses_css_whitelist():
+    runner = SlideEditToolRunner(_tool_context())
+
+    result = await runner.execute_tool(
+        "update_style",
+        {
+            "selector": "h1",
+            "styles": {
+                "color": "#123456",
+                "font-size": "48px",
+                "position": "fixed",
+                "behavior": "url(bad)",
+            },
+        },
+    )
+
+    assert result["success"] is True
+    assert "color: #123456" in runner.current_html
+    assert "font-size: 48px" in runner.current_html
+    assert "position: fixed" not in runner.current_html
+    assert "behavior" not in runner.current_html
+
+
+@pytest.mark.asyncio
+async def test_tool_runner_replaces_element_and_preserves_quick_ai_id_in_draft():
+    runner = SlideEditToolRunner(
+        _tool_context(
+            mode="element",
+            selectedElementHtml='<h1 data-quick-ai-id="el1">Long Original Title</h1>',
+            selectedElementId="el1",
+        )
+    )
+
+    result = await runner.execute_tool(
+        "replace_element_html",
+        {"element_id": "el1", "html": '<h1 data-quick-ai-id="el1">Short Title</h1>'},
+    )
+
+    assert result["success"] is True
+    assert 'data-quick-ai-id="el1"' in runner.current_html
+    assert "Short Title" in runner.current_html
+
+
+def test_tool_runner_build_proposal_strips_agent_ids():
+    runner = SlideEditToolRunner(
+        _tool_context(
+            slideContent='<div style="width:1280px;height:720px"><h1 data-agent-id="a1">Title</h1></div>'
+        )
+    )
+
+    proposal = runner.build_proposal("Edited title")
+
+    assert proposal.proposal_id
+    assert proposal.summary == "Edited title"
+    assert "data-agent-id" not in proposal.html_content
+    assert proposal.validation.valid is True

--- a/tests/test_slide_edit_agent_service.py
+++ b/tests/test_slide_edit_agent_service.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 
 from landppt.services.slide.slide_edit_agent_service import (
@@ -71,6 +70,14 @@ def test_validate_slide_html_reports_unsafe_original_html():
     assert "script tags are not allowed" in result.errors
     assert "inline event handlers are not allowed" in result.errors
     assert "<script" not in result.sanitized_html.lower()
+
+
+def test_validate_slide_html_rejects_encoded_javascript_urls():
+    result = validate_slide_html('<div><a href="java&#115;cript:alert(1)">x</a></div>')
+
+    assert result.valid is False
+    assert "javascript urls are not allowed" in result.errors
+    assert "javascript:" not in result.sanitized_html.lower()
 
 
 def test_validate_slide_html_accepts_clean_slide_html():

--- a/tests/test_slide_edit_agent_service.py
+++ b/tests/test_slide_edit_agent_service.py
@@ -86,6 +86,33 @@ def test_validate_slide_html_rejects_encoded_javascript_urls():
     assert result.valid is False
     assert "javascript urls are not allowed" in result.errors
     assert "javascript:" not in result.sanitized_html.lower()
+    assert "href=" not in result.sanitized_html.lower()
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        '<div><a href="java&#10;script:alert(1)">x</a></div>',
+        '<div><a href="jav&#x09;ascript:alert(1)">x</a></div>',
+    ],
+)
+def test_validate_slide_html_rejects_encoded_control_javascript_urls(html):
+    result = validate_slide_html(html)
+
+    assert result.valid is False
+    assert "javascript urls are not allowed" in result.errors
+    assert "href=" not in result.sanitized_html.lower()
+
+
+def test_validate_slide_html_rejects_srcdoc_attributes():
+    result = validate_slide_html(
+        '<div><iframe srcdoc="&lt;script&gt;alert(1)&lt;/script&gt;"></iframe></div>'
+    )
+
+    assert result.valid is False
+    assert "srcdoc attributes are not allowed" in result.errors
+    assert "srcdoc" not in result.sanitized_html.lower()
+    assert "<script" not in result.sanitized_html.lower()
 
 
 def test_validate_slide_html_accepts_clean_slide_html():

--- a/tests/test_slide_edit_agent_service.py
+++ b/tests/test_slide_edit_agent_service.py
@@ -289,6 +289,38 @@ async def test_tool_runner_insert_element_rejects_unsafe_fragment_without_mutati
 
 
 @pytest.mark.asyncio
+async def test_tool_runner_insert_element_missing_target_fails_without_mutating_full_html_body():
+    html = (
+        "<!doctype html><html><head><title>Slide</title></head>"
+        '<body><section id="slide"><p>Body</p></section></body></html>'
+    )
+    runner = SlideEditToolRunner(_tool_context(slideContent=html))
+    original_html = runner.current_html
+
+    result = await runner.execute_tool("insert_element", {"html": "<p>New</p>"})
+
+    assert result["success"] is False
+    assert result["tool"] == "insert_element"
+    assert "requires parent_selector or element_id" in result["error"]
+    assert runner.current_html == original_html
+    assert "New" not in runner.current_html
+
+
+@pytest.mark.asyncio
+async def test_tool_runner_insert_element_succeeds_with_explicit_parent_selector():
+    runner = SlideEditToolRunner(_tool_context())
+
+    result = await runner.execute_tool(
+        "insert_element",
+        {"parent_selector": "div", "html": "<h2>New Section</h2>"},
+    )
+
+    assert result["success"] is True
+    assert result["tool"] == "insert_element"
+    assert "<h2>New Section</h2>" in runner.current_html
+
+
+@pytest.mark.asyncio
 async def test_tool_runner_invalid_selector_returns_structured_error():
     runner = SlideEditToolRunner(_tool_context())
     original_html = runner.current_html

--- a/tests/test_slide_edit_agent_service.py
+++ b/tests/test_slide_edit_agent_service.py
@@ -181,6 +181,11 @@ async def test_tool_runner_replaces_element_and_preserves_quick_ai_id_in_draft()
     runner = SlideEditToolRunner(
         _tool_context(
             mode="element",
+            slideContent=(
+                '<div style="width:1280px;height:720px">'
+                '<h1 data-quick-ai-id="el1">Long Original Title</h1><p>Body</p>'
+                "</div>"
+            ),
             selectedElementHtml='<h1 data-quick-ai-id="el1">Long Original Title</h1>',
             selectedElementId="el1",
         )
@@ -194,6 +199,83 @@ async def test_tool_runner_replaces_element_and_preserves_quick_ai_id_in_draft()
     assert result["success"] is True
     assert 'data-quick-ai-id="el1"' in runner.current_html
     assert "Short Title" in runner.current_html
+
+
+@pytest.mark.asyncio
+async def test_tool_runner_replace_element_missing_id_fails_without_mutating_draft():
+    runner = SlideEditToolRunner(
+        _tool_context(
+            mode="element",
+            selectedElementId="missing",
+        )
+    )
+    original_html = runner.current_html
+
+    result = await runner.execute_tool(
+        "replace_element_html",
+        {"element_id": "missing", "html": "<h1>Short Title</h1>"},
+    )
+
+    assert result["success"] is False
+    assert result["tool"] == "replace_element_html"
+    assert "not found" in result["error"]
+    assert runner.current_html == original_html
+
+
+@pytest.mark.asyncio
+async def test_tool_runner_replace_element_rejects_unsafe_fragment_without_mutating_draft():
+    runner = SlideEditToolRunner(
+        _tool_context(
+            mode="element",
+            slideContent=(
+                '<div style="width:1280px;height:720px">'
+                '<h1 data-quick-ai-id="el1">Long Original Title</h1><p>Body</p>'
+                "</div>"
+            ),
+            selectedElementId="el1",
+        )
+    )
+    original_html = runner.current_html
+
+    result = await runner.execute_tool(
+        "replace_element_html",
+        {"element_id": "el1", "html": '<h1 onclick="bad()">Bad</h1>'},
+    )
+
+    assert result["success"] is False
+    assert "inline event handlers are not allowed" in result["errors"]
+    assert runner.current_html == original_html
+
+
+@pytest.mark.asyncio
+async def test_tool_runner_insert_element_rejects_unsafe_fragment_without_mutating_draft():
+    runner = SlideEditToolRunner(_tool_context())
+    original_html = runner.current_html
+
+    result = await runner.execute_tool(
+        "insert_element",
+        {"parent_selector": "div", "html": "<h2><script>alert(1)</script>Bad</h2>"},
+    )
+
+    assert result["success"] is False
+    assert "script tags are not allowed" in result["errors"]
+    assert runner.current_html == original_html
+
+
+@pytest.mark.asyncio
+async def test_tool_runner_invalid_selector_returns_structured_error():
+    runner = SlideEditToolRunner(_tool_context())
+    original_html = runner.current_html
+
+    result = await runner.execute_tool(
+        "update_text",
+        {"selector": "[", "text": "Short Title"},
+    )
+
+    assert result["success"] is False
+    assert result["tool"] == "update_text"
+    assert "invalid selector" in result["error"]
+    assert runner.current_html == original_html
 
 
 def test_tool_runner_build_proposal_strips_agent_ids():

--- a/tests/test_slide_edit_agent_service.py
+++ b/tests/test_slide_edit_agent_service.py
@@ -1,10 +1,12 @@
 import json
+from types import SimpleNamespace
 
 import pytest
 
 from landppt.services.slide.slide_edit_agent_service import (
     SlideEditAgentContext,
     SlideEditAgentRequest,
+    SlideEditAgentService,
     SlideEditToolRunner,
     compute_slide_html_hash,
     coerce_agent_max_iterations,
@@ -348,4 +350,124 @@ def test_tool_runner_build_proposal_strips_agent_ids():
     assert proposal.proposal_id
     assert proposal.summary == "Edited title"
     assert "data-agent-id" not in proposal.html_content
+    assert proposal.validation.valid is True
+
+
+class _FakePPTService:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def _chat_completion_for_role(self, role, messages):
+        self.calls.append((role, messages))
+        return SimpleNamespace(content=self.responses.pop(0))
+
+
+@pytest.mark.asyncio
+async def test_slide_edit_agent_runs_tools_and_returns_proposal():
+    service = SlideEditAgentService()
+    fake_ppt = _FakePPTService(
+        [
+            json.dumps(
+                {
+                    "thought": "Inspect before editing.",
+                    "action": "inspect_slide_html",
+                    "action_input": {"slide_index": 1},
+                }
+            ),
+            json.dumps(
+                {
+                    "thought": "Update the title text.",
+                    "action": "update_text",
+                    "action_input": {"selector": "h1", "text": "Short Title"},
+                }
+            ),
+            json.dumps(
+                {
+                    "thought": "The title is shorter and ready.",
+                    "action": "final",
+                    "action_input": {"summary": "Shortened the title."},
+                }
+            ),
+        ]
+    )
+    events = []
+
+    async def capture(event):
+        events.append(event)
+
+    proposal = await service.run_agent(_tool_request(), fake_ppt, capture)
+
+    assert proposal.summary == "Shortened the title."
+    assert "Short Title" in proposal.html_content
+    assert proposal.validation.valid is True
+    assert [event["type"] for event in events if event["type"] == "tool_call"] == [
+        "tool_call",
+        "tool_call",
+    ]
+    assert {event["type"] for event in events} >= {
+        "agent_start",
+        "agent_step",
+        "tool_result",
+        "draft_ready",
+        "needs_confirmation",
+    }
+
+
+@pytest.mark.asyncio
+async def test_slide_edit_agent_reports_unsupported_tool_and_continues():
+    service = SlideEditAgentService()
+    fake_ppt = _FakePPTService(
+        [
+            json.dumps(
+                {
+                    "thought": "Try an unknown tool.",
+                    "action": "bad_tool",
+                    "action_input": {},
+                }
+            ),
+            json.dumps(
+                {
+                    "thought": "Finish without change.",
+                    "action": "final",
+                    "action_input": {"summary": "No safe change."},
+                }
+            ),
+        ]
+    )
+
+    proposal = await service.run_agent(_tool_request(maxIterations=3), fake_ppt)
+
+    assert proposal.summary == "No safe change."
+    assert proposal.tool_transcript == []
+
+
+@pytest.mark.asyncio
+async def test_slide_edit_agent_finalizes_when_max_iterations_is_reached():
+    service = SlideEditAgentService()
+    fake_ppt = _FakePPTService(
+        [
+            json.dumps(
+                {
+                    "thought": "Inspect.",
+                    "action": "inspect_slide_html",
+                    "action_input": {},
+                }
+            ),
+            json.dumps(
+                {
+                    "thought": "Inspect again.",
+                    "action": "inspect_slide_html",
+                    "action_input": {},
+                }
+            ),
+        ]
+    )
+
+    proposal = await service.run_agent(_tool_request(maxIterations=2), fake_ppt)
+
+    assert (
+        proposal.summary
+        == "Reached the maximum edit iterations and prepared the current draft."
+    )
     assert proposal.validation.valid is True

--- a/tests/test_slideshow_interactivity.py
+++ b/tests/test_slideshow_interactivity.py
@@ -1,0 +1,21 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_editor_slideshow_shield_does_not_block_slide_interactions():
+    template = _read("src/landppt/web/templates/pages/project/project_slides_editor.html")
+    css = _read("src/landppt/web/static/css/pages/project/slides_editor/projectSlidesEditor.css")
+
+    assert 'id="slideshowShield"' in template
+    assert re.search(
+        r"\.slideshow-shield\s*\{[^}]*pointer-events\s*:\s*none",
+        css,
+        flags=re.DOTALL,
+    )

--- a/tests/test_web_route_modularization.py
+++ b/tests/test_web_route_modularization.py
@@ -34,6 +34,21 @@ def test_main_router_registers_extracted_route_modules():
     assert "router.include_router(template_router)" in routes_text
 
 
+def test_slide_edit_agent_routes_are_registered():
+    routes_text = _read("src/landppt/web/routes.py")
+    agent_text = _read("src/landppt/web/route_modules/slide_edit_agent_routes.py")
+
+    assert "from .route_modules.slide_edit_agent_routes import router as slide_edit_agent_router" in routes_text
+    assert "router.include_router(slide_edit_agent_router)" in routes_text
+
+    for marker in [
+        '@router.post("/api/ai/slide-edit-agent/stream")',
+        '@router.post("/api/ai/slide-edit-agent/apply")',
+        '@router.post("/api/ai/slide-edit-agent/cancel")',
+    ]:
+        assert marker in agent_text
+
+
 def test_legacy_route_handlers_were_removed_from_main_router_file():
     routes_text = _read("src/landppt/web/routes.py")
 


### PR DESCRIPTION
## Summary
- Add the slide editing agent loop, draft PPT editing tools, streaming routes, and sidebar proposal/apply workflow.
- Route quick element AI edits through the agent workflow while keeping saved slide HTML clean.
- Preserve interactive slide HTML in exported HTML ZIP packages, keep hyperlinks clickable, remove duplicate slide viewer files, and allow interactions in editor slideshow mode.

## Tests
- `uv run --extra dev pytest tests/test_slide_edit_agent_service.py tests/test_slide_edit_agent_routes.py -q`
- `uv run --extra dev pytest tests/test_export_support_models.py tests/test_slideshow_interactivity.py -q`
- `uv run --extra dev pytest tests/test_web_route_modularization.py::test_extracted_route_modules_keep_expected_public_paths tests/test_web_route_modularization.py::test_project_slides_editor_template_uses_extracted_assets -q`