### PR TITLE
Fix slide edit agent history and slideshow wheel events

### DIFF
--- a/src/landppt/services/slide/slide_edit_agent_service.py
+++ b/src/landppt/services/slide/slide_edit_agent_service.py
@@ -15,6 +15,10 @@ from pydantic import BaseModel
 
 AgentEditMode = Literal["slide", "element"]
 
+_MAX_CONVERSATION_HISTORY_MESSAGES = 10
+_MAX_CONVERSATION_HISTORY_TOTAL_CHARS = 6000
+_MAX_CONVERSATION_HISTORY_MESSAGE_CHARS = 1200
+
 
 class SlideEditAgentRequest(BaseModel):
     projectId: str
@@ -1008,6 +1012,7 @@ class SlideEditAgentService:
             "selected_element_id": request.selectedElementId,
             "selected_element_html": request.selectedElementHtml,
             "user_request": request.userRequest,
+            "conversation_history": self._conversation_history_context(request),
             "current_html": runner.current_html,
             "vision": self._vision_context(request),
             "available_tools": self._tool_schemas(runner),
@@ -1016,9 +1021,58 @@ class SlideEditAgentService:
         }
         return (
             "Use a ReAct loop to edit this PPT slide. Choose exactly one action. "
-            "Use final when the draft is ready. Return strict JSON only.\n\n"
+            "Use conversation_history for continuity, but execute the latest "
+            "user_request. Use final when the draft is ready. Return strict JSON only.\n\n"
             + json.dumps(context, ensure_ascii=False, indent=2)
         )
+
+    def _conversation_history_context(
+        self, request: SlideEditAgentRequest
+    ) -> List[Dict[str, str]]:
+        cleaned: List[Dict[str, str]] = []
+        total_chars = 0
+
+        for item in reversed(request.chatHistory or []):
+            if len(cleaned) >= _MAX_CONVERSATION_HISTORY_MESSAGES:
+                break
+            if not isinstance(item, dict):
+                continue
+
+            role = str(item.get("role") or "").strip().lower()
+            if role not in {"user", "assistant"}:
+                continue
+
+            content = str(item.get("content") or "").strip()
+            if not content:
+                continue
+
+            remaining_chars = _MAX_CONVERSATION_HISTORY_TOTAL_CHARS - total_chars
+            if remaining_chars <= 0:
+                break
+
+            max_chars = min(
+                remaining_chars,
+                _MAX_CONVERSATION_HISTORY_MESSAGE_CHARS,
+            )
+            content = self._truncate_history_content(content, max_chars)
+            if not content:
+                continue
+
+            cleaned.append({"role": role, "content": content})
+            total_chars += len(content)
+
+        cleaned.reverse()
+        return cleaned
+
+    @staticmethod
+    def _truncate_history_content(content: str, max_chars: int) -> str:
+        if max_chars <= 0:
+            return ""
+        if len(content) <= max_chars:
+            return content
+        if max_chars <= 3:
+            return content[:max_chars]
+        return content[: max_chars - 3].rstrip() + "..."
 
     def _vision_context(self, request: SlideEditAgentRequest) -> Dict[str, Any]:
         attachments: List[Dict[str, Any]] = []

--- a/src/landppt/web/route_modules/export_support.py
+++ b/src/landppt/web/route_modules/export_support.py
@@ -480,6 +480,7 @@ def _generate_html_export_sync(project, base_url: Optional[str] = None) -> bytes
             raw_html = _wrap_raw_slide_html_sync(slide, project.topic)
             if export_base_url:
                 raw_html = _prepare_html_for_file_based_export(raw_html, export_base_url)
+            raw_html = _inject_projector_child_wheel_bridge(raw_html)
             with open(raw_dir / slide_filename, 'w', encoding='utf-8') as f:
                 f.write(raw_html)
 
@@ -649,15 +650,142 @@ _UI_AUTO_HIDE_JS = """
 # 在.overview（目录）内滚动时不拦截，保持列表原生滚动。
 _WHEEL_NAV_JS = """
         var wheelLockUntil = 0;
-        document.addEventListener('wheel', function (e) {
+        function canScrollProjectorWheelTarget(target, deltaY) {
+            var doc = target && target.ownerDocument;
+            var win = doc && (doc.defaultView || window);
+            if (!doc || !win) return false;
+
+            var node = target;
+            while (node && node.nodeType === 1) {
+                var style = win.getComputedStyle(node);
+                var overflowY = (style.overflowY || '') + ' ' + (style.overflow || '');
+                var canScrollY = /(auto|scroll|overlay)/.test(overflowY)
+                    && node.scrollHeight > node.clientHeight + 1;
+
+                if (canScrollY) {
+                    var canScrollDown = deltaY > 0
+                        && node.scrollTop + node.clientHeight < node.scrollHeight - 1;
+                    var canScrollUp = deltaY < 0 && node.scrollTop > 1;
+                    if (canScrollDown || canScrollUp) return true;
+                }
+
+                if (node === doc.body || node === doc.documentElement) break;
+                node = node.parentElement;
+            }
+            return false;
+        }
+
+        function shouldPreserveProjectorWheelTarget(target, deltaY) {
+            if (!target || typeof target.closest !== 'function') return false;
+            if (target.closest('input, textarea, select, option, [contenteditable="true"], [contenteditable=""], [role="textbox"]')) {
+                return true;
+            }
+            return canScrollProjectorWheelTarget(target, deltaY);
+        }
+
+        function handleProjectorWheel(e) {
             if (e.target.closest && e.target.closest('.overview')) return;
+            if (shouldPreserveProjectorWheelTarget(e.target, e.deltaY)) return;
             e.preventDefault();
+            navigateProjectorWheel(e.deltaY);
+        }
+
+        function navigateProjectorWheel(deltaY) {
             var now = Date.now();
-            if (now < wheelLockUntil || Math.abs(e.deltaY) < 4) return;
+            if (now < wheelLockUntil || Math.abs(deltaY) < 4) return;
             wheelLockUntil = now + 350;
-            if (e.deltaY > 0) { wheelNext(); } else { wheelPrev(); }
-        }, { passive: false });
+            if (deltaY > 0) { wheelNext(); } else { wheelPrev(); }
+        }
+
+        function installSlideFrameWheelBridge() {
+            var frame = document.getElementById('slideFrame');
+            if (!frame) return;
+            try {
+                var frameWindow = frame.contentWindow;
+                var frameDocument = frame.contentDocument || (frameWindow && frameWindow.document);
+                if (!frameWindow || !frameDocument || frameWindow.__landpptProjectorWheelBridgeInstalled) return;
+                frameWindow.__landpptProjectorWheelBridgeInstalled = true;
+                frameDocument.addEventListener('wheel', handleProjectorWheel, { passive: false });
+            } catch (error) {
+                // Ignore inaccessible frames; exported slide files are same-origin.
+            }
+        }
+
+        document.addEventListener('wheel', handleProjectorWheel, { passive: false });
+        window.addEventListener('message', function (e) {
+            var data = e.data || {};
+            if (!data || data.type !== 'landppt-projector-wheel') return;
+            if (!slideFrame || e.source !== slideFrame.contentWindow) return;
+            navigateProjectorWheel(Number(data.deltaY) || 0);
+        });
+        if (slideFrame) {
+            slideFrame.addEventListener('load', installSlideFrameWheelBridge);
+        }
+        installSlideFrameWheelBridge();
 """
+
+
+_PROJECTOR_CHILD_WHEEL_BRIDGE_SCRIPT = """<script>
+(function () {
+    if (window.parent === window) return;
+    function canScrollWheelTarget(target, deltaY) {
+        var doc = target && target.ownerDocument;
+        var win = doc && (doc.defaultView || window);
+        if (!doc || !win) return false;
+
+        var node = target;
+        while (node && node.nodeType === 1) {
+            var style = win.getComputedStyle(node);
+            var overflowY = (style.overflowY || '') + ' ' + (style.overflow || '');
+            var canScrollY = /(auto|scroll|overlay)/.test(overflowY)
+                && node.scrollHeight > node.clientHeight + 1;
+
+            if (canScrollY) {
+                var canScrollDown = deltaY > 0
+                    && node.scrollTop + node.clientHeight < node.scrollHeight - 1;
+                var canScrollUp = deltaY < 0 && node.scrollTop > 1;
+                if (canScrollDown || canScrollUp) return true;
+            }
+
+            if (node === doc.body || node === doc.documentElement) break;
+            node = node.parentElement;
+        }
+        return false;
+    }
+
+    function shouldPreserveWheelTarget(target, deltaY) {
+        if (!target || typeof target.closest !== 'function') return false;
+        if (target.closest('input, textarea, select, option, [contenteditable="true"], [contenteditable=""], [role="textbox"]')) {
+            return true;
+        }
+        return canScrollWheelTarget(target, deltaY);
+    }
+
+    document.addEventListener('wheel', function (e) {
+        if (shouldPreserveWheelTarget(e.target, e.deltaY)) return;
+        e.preventDefault();
+        window.parent.postMessage({ type: 'landppt-projector-wheel', deltaY: e.deltaY }, '*');
+    }, { passive: false });
+})();
+</script>"""
+
+
+def _inject_projector_child_wheel_bridge(html_content: str) -> str:
+    if not isinstance(html_content, str) or not html_content.strip():
+        return html_content
+    if "landppt-projector-wheel" in html_content:
+        return html_content
+
+    if re.search(r"</body\s*>", html_content, flags=re.IGNORECASE):
+        return re.sub(
+            r"</body\s*>",
+            lambda match: f"{_PROJECTOR_CHILD_WHEEL_BRIDGE_SCRIPT}\n{match.group(0)}",
+            html_content,
+            count=1,
+            flags=re.IGNORECASE,
+        )
+
+    return f"{html_content}\n{_PROJECTOR_CHILD_WHEEL_BRIDGE_SCRIPT}"
 
 
 def _generate_individual_slide_html_sync(slide, slide_number: int, total_slides: int, topic: str) -> str:

--- a/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.slideshow.js
+++ b/src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.slideshow.js
@@ -124,6 +124,64 @@ function scheduleSlideshowFrameScale() {
     requestAnimationFrame(applySlideshowFrameScale);
 }
 
+function canScrollSlideshowWheelTarget(target, deltaY) {
+    const doc = target && target.ownerDocument;
+    const win = doc && (doc.defaultView || window);
+    if (!doc || !win) return false;
+
+    let node = target;
+    while (node && node.nodeType === 1) {
+        const style = win.getComputedStyle(node);
+        const overflowY = `${style.overflowY || ''} ${style.overflow || ''}`;
+        const canScrollY = /(auto|scroll|overlay)/.test(overflowY)
+            && node.scrollHeight > node.clientHeight + 1;
+
+        if (canScrollY) {
+            const canScrollDown = deltaY > 0
+                && node.scrollTop + node.clientHeight < node.scrollHeight - 1;
+            const canScrollUp = deltaY < 0 && node.scrollTop > 1;
+            if (canScrollDown || canScrollUp) {
+                return true;
+            }
+        }
+
+        if (node === doc.body || node === doc.documentElement) {
+            break;
+        }
+        node = node.parentElement;
+    }
+    return false;
+}
+
+function shouldPreserveSlideshowWheelTarget(target, deltaY) {
+    if (!target || typeof target.closest !== 'function') return false;
+    if (target.closest('input, textarea, select, option, [contenteditable="true"], [contenteditable=""], [role="textbox"]')) {
+        return true;
+    }
+    return canScrollSlideshowWheelTarget(target, deltaY);
+}
+
+function handleSlideshowFrameWheel(e) {
+    if (!isSlideshow) return;
+    if (shouldPreserveSlideshowWheelTarget(e.target, e.deltaY)) return;
+    handleSlideshowWheel(e);
+}
+
+function installSlideshowFrameWheelBridge(iframe) {
+    if (!iframe) return;
+    try {
+        const frameWindow = iframe.contentWindow;
+        const frameDoc = iframe.contentDocument || (frameWindow && frameWindow.document);
+        if (!frameWindow || !frameDoc || frameWindow.__landpptSlideshowWheelBridgeInstalled) {
+            return;
+        }
+        frameWindow.__landpptSlideshowWheelBridgeInstalled = true;
+        frameDoc.addEventListener('wheel', handleSlideshowFrameWheel, { passive: false });
+    } catch (error) {
+        // Cross-origin frames cannot be bridged; srcdoc slideshow frames are same-origin.
+    }
+}
+
 // 遮罩层点击翻页
 function handleSlideshowShieldClick() {
     nextSlideshow();
@@ -134,6 +192,7 @@ let slideshowWheelLockUntil = 0;
 
 function handleSlideshowWheel(e) {
     if (!isSlideshow) return;
+    if (shouldPreserveSlideshowWheelTarget(e.target, e.deltaY)) return;
     e.preventDefault();
     const now = Date.now();
     if (now < slideshowWheelLockUntil || Math.abs(e.deltaY) < 4) return;
@@ -326,6 +385,7 @@ function setSafeIframeContentNoFlash(iframe, html, callback) {
 
     // 检查内容是否相同，避免不必要的更新
     if (iframe.getAttribute('data-current-content') === html) {
+        installSlideshowFrameWheelBridge(iframe);
         if (callback) callback();
         return;
     }
@@ -338,6 +398,7 @@ function setSafeIframeContentNoFlash(iframe, html, callback) {
         // 监听加载完成
         const handleLoad = () => {
             iframe.removeEventListener('load', handleLoad);
+            installSlideshowFrameWheelBridge(iframe);
             if (callback) {
                 // 短暂延迟确保内容完全渲染
                 setTimeout(callback, 50);
@@ -349,6 +410,7 @@ function setSafeIframeContentNoFlash(iframe, html, callback) {
         // 备用超时机制
         setTimeout(() => {
             iframe.removeEventListener('load', handleLoad);
+            installSlideshowFrameWheelBridge(iframe);
             if (callback) callback();
         }, 500);
 

--- a/tests/test_export_support_models.py
+++ b/tests/test_export_support_models.py
@@ -128,11 +128,19 @@ def test_html_zip_export_keeps_interactive_slide_html_without_duplicate_viewers(
         assert 'src="slides/slide_1.html"' in index_html
         assert ".stage-shield" in index_html
         assert "pointer-events: none" in index_html
+        assert "function installSlideFrameWheelBridge()" in index_html
+        assert "frameDocument.addEventListener('wheel', handleProjectorWheel" in index_html
+        assert "slideFrame.addEventListener('load', installSlideFrameWheelBridge)" in index_html
+        assert "window.addEventListener('message'" in index_html
+        assert "landppt-projector-wheel" in index_html
+        assert "input, textarea, select" in index_html
 
         first_slide = archive.read("slides/slide_1.html").decode("utf-8")
         assert 'href="https://example.com/path"' in first_slide
         assert 'onclick="window.clicked = true"' in first_slide
         assert "<script>window.loaded = true;</script>" in first_slide
+        assert "window.parent.postMessage({ type: 'landppt-projector-wheel'" in first_slide
 
         second_slide = archive.read("slides/slide_2.html").decode("utf-8")
         assert 'onclick="window.second = true"' in second_slide
+        assert "window.parent.postMessage({ type: 'landppt-projector-wheel'" in second_slide

--- a/tests/test_slide_edit_agent_service.py
+++ b/tests/test_slide_edit_agent_service.py
@@ -381,6 +381,53 @@ def test_tool_runner_build_proposal_strips_agent_ids():
     assert proposal.validation.valid is True
 
 
+def _agent_prompt_context(service: SlideEditAgentService, request: SlideEditAgentRequest):
+    runner = SlideEditToolRunner(SlideEditAgentContext.from_request(request))
+    prompt = service._build_prompt(request, runner, scratchpad=[], max_iterations=6)
+    return json.loads(prompt.split("\n\n", 1)[1])
+
+
+def test_slide_edit_agent_prompt_includes_sanitized_conversation_history():
+    service = SlideEditAgentService()
+    request = _tool_request(
+        chatHistory=[
+            {"role": "system", "content": "Do not include this."},
+            {"role": "user", "content": "Make the heading shorter first."},
+            {"role": "assistant", "content": "I shortened the heading."},
+            {"role": "tool", "content": "Internal tool output."},
+            {"role": "assistant", "content": "   "},
+        ]
+    )
+
+    context = _agent_prompt_context(service, request)
+
+    assert context["conversation_history"] == [
+        {"role": "user", "content": "Make the heading shorter first."},
+        {"role": "assistant", "content": "I shortened the heading."},
+    ]
+    assert context["user_request"] == "Make the title shorter"
+
+
+def test_slide_edit_agent_prompt_limits_conversation_history_to_recent_messages():
+    service = SlideEditAgentService()
+    history = [
+        {"role": "user", "content": f"message {index}"}
+        for index in range(14)
+    ]
+    history.append({"role": "assistant", "content": "x" * 1500})
+    request = _tool_request(chatHistory=history)
+
+    context = _agent_prompt_context(service, request)
+    conversation_history = context["conversation_history"]
+
+    assert len(conversation_history) == 10
+    assert conversation_history[0] == {"role": "user", "content": "message 5"}
+    assert conversation_history[-2] == {"role": "user", "content": "message 13"}
+    assert conversation_history[-1]["role"] == "assistant"
+    assert conversation_history[-1]["content"].endswith("...")
+    assert len(conversation_history[-1]["content"]) <= 1200
+
+
 class _FakePPTService:
     def __init__(self, responses):
         self.responses = list(responses)

--- a/tests/test_slideshow_interactivity.py
+++ b/tests/test_slideshow_interactivity.py
@@ -19,3 +19,15 @@ def test_editor_slideshow_shield_does_not_block_slide_interactions():
         css,
         flags=re.DOTALL,
     )
+
+
+def test_editor_slideshow_bridges_iframe_wheel_navigation():
+    script = _read(
+        "src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.slideshow.js"
+    )
+
+    assert "function installSlideshowFrameWheelBridge(iframe)" in script
+    assert "frameDoc.addEventListener('wheel', handleSlideshowFrameWheel" in script
+    assert "installSlideshowFrameWheelBridge(iframe);" in script
+    assert "function shouldPreserveSlideshowWheelTarget(target, deltaY)" in script
+    assert "input, textarea, select" in script


### PR DESCRIPTION
## Summary
- Preserve same-slide chat history in the slide edit agent prompt.
- Sanitize and bound conversation history before adding it to the agent context.
- Bridge wheel events from slideshow iframes so editor slideshow mode and exported HTML index pages can navigate with the mouse wheel without blocking slide interactions.
- Inject a child-frame wheel bridge into exported slide HTML for reliable local ZIP playback.

## Tests
- `uv run --extra dev pytest tests/test_slide_edit_agent_service.py -q`
- `uv run --extra dev pytest tests/test_slide_edit_agent_routes.py -q`
- `uv run --extra dev pytest tests/test_export_support_models.py tests/test_slideshow_interactivity.py -q`
- `uv run --extra dev pytest tests/test_web_route_modularization.py::test_extracted_route_modules_keep_expected_public_paths tests/test_web_route_modularization.py::test_project_slides_editor_template_uses_extracted_assets -q`
- `node --check src/landppt/web/static/js/pages/project/slides_editor/projectSlidesEditor.slideshow.js`