### PR TITLE
Fix exported HTML projector keyboard navigation

### DIFF
--- a/src/landppt/web/route_modules/export_support.py
+++ b/src/landppt/web/route_modules/export_support.py
@@ -632,6 +632,26 @@ _PROJECTOR_STAGE_CSS = """
 
 _UI_AUTO_HIDE_JS = """
         var uiHideTimer = null;
+        function shouldRevealUiForKey(e) {
+            var key = e && e.key;
+            if (!key) return true;
+            var navigationKeys = {
+                ArrowLeft: true,
+                ArrowRight: true,
+                ArrowUp: true,
+                ArrowDown: true,
+                PageUp: true,
+                PageDown: true,
+                Home: true,
+                End: true,
+                ' ': true,
+                Spacebar: true,
+                Enter: true
+            };
+            if (navigationKeys[key]) return false;
+            if (key >= '1' && key <= '9') return false;
+            return true;
+        }
         function revealUi() {
             document.body.classList.remove('ui-hidden');
             if (uiHideTimer) clearTimeout(uiHideTimer);
@@ -640,7 +660,9 @@ _UI_AUTO_HIDE_JS = """
             }, 2500);
         }
         document.addEventListener('mousemove', revealUi);
-        document.addEventListener('keydown', revealUi);
+        document.addEventListener('keydown', function (e) {
+            if (shouldRevealUiForKey(e)) revealUi();
+        });
         document.addEventListener('touchstart', revealUi, { passive: true });
         revealUi();
 """
@@ -714,9 +736,15 @@ _WHEEL_NAV_JS = """
         document.addEventListener('wheel', handleProjectorWheel, { passive: false });
         window.addEventListener('message', function (e) {
             var data = e.data || {};
-            if (!data || data.type !== 'landppt-projector-wheel') return;
+            if (!data) return;
             if (!slideFrame || e.source !== slideFrame.contentWindow) return;
-            navigateProjectorWheel(Number(data.deltaY) || 0);
+            if (data.type === 'landppt-projector-wheel') {
+                navigateProjectorWheel(Number(data.deltaY) || 0);
+                return;
+            }
+            if (data.type === 'landppt-projector-key' && typeof handleProjectorKey === 'function') {
+                handleProjectorKey(String(data.key || ''));
+            }
         });
         if (slideFrame) {
             slideFrame.addEventListener('load', installSlideFrameWheelBridge);
@@ -770,22 +798,106 @@ _PROJECTOR_CHILD_WHEEL_BRIDGE_SCRIPT = """<script>
 </script>"""
 
 
+_PROJECTOR_CHILD_KEY_BRIDGE_SCRIPT = """<script>
+(function () {
+    if (window.parent === window) return;
+
+    function shouldPreserveKeyTarget(target) {
+        if (!target || typeof target.closest !== 'function') return false;
+        if (target.isContentEditable) return true;
+        return Boolean(target.closest([
+            'a[href]',
+            'button',
+            'input',
+            'textarea',
+            'select',
+            'option',
+            'summary',
+            'canvas',
+            'iframe',
+            'audio[controls]',
+            'video[controls]',
+            '[contenteditable="true"]',
+            '[contenteditable=""]',
+            '[tabindex]:not([tabindex="-1"])',
+            '[role="application"]',
+            '[role="button"]',
+            '[role="checkbox"]',
+            '[role="combobox"]',
+            '[role="dialog"]',
+            '[role="grid"]',
+            '[role="link"]',
+            '[role="listbox"]',
+            '[role="menu"]',
+            '[role="menuitem"]',
+            '[role="radio"]',
+            '[role="slider"]',
+            '[role="spinbutton"]',
+            '[role="switch"]',
+            '[role="tab"]',
+            '[role="textbox"]',
+            '[role="tree"]',
+            '[role="treeitem"]'
+        ].join(',')));
+    }
+
+    function isProjectorKey(key) {
+        var keys = {
+            ArrowLeft: true,
+            ArrowRight: true,
+            ArrowUp: true,
+            ArrowDown: true,
+            PageUp: true,
+            PageDown: true,
+            Home: true,
+            End: true,
+            ' ': true,
+            Spacebar: true,
+            Enter: true,
+            Escape: true,
+            f: true,
+            F: true,
+            g: true,
+            G: true
+        };
+        return Boolean(keys[key] || (key >= '1' && key <= '9'));
+    }
+
+    window.addEventListener('keydown', function (e) {
+        if (e.defaultPrevented) return;
+        if (e.altKey || e.ctrlKey || e.metaKey) return;
+        if (!isProjectorKey(e.key) || shouldPreserveKeyTarget(e.target)) return;
+        e.preventDefault();
+        window.parent.postMessage({ type: 'landppt-projector-key', key: e.key }, '*');
+    });
+})();
+</script>"""
+
+
 def _inject_projector_child_wheel_bridge(html_content: str) -> str:
     if not isinstance(html_content, str) or not html_content.strip():
         return html_content
-    if "landppt-projector-wheel" in html_content:
+
+    bridge_scripts = []
+    if "landppt-projector-wheel" not in html_content:
+        bridge_scripts.append(_PROJECTOR_CHILD_WHEEL_BRIDGE_SCRIPT)
+    if "landppt-projector-key" not in html_content:
+        bridge_scripts.append(_PROJECTOR_CHILD_KEY_BRIDGE_SCRIPT)
+    if not bridge_scripts:
         return html_content
+
+    bridge_script = "\n".join(bridge_scripts)
 
     if re.search(r"</body\s*>", html_content, flags=re.IGNORECASE):
         return re.sub(
             r"</body\s*>",
-            lambda match: f"{_PROJECTOR_CHILD_WHEEL_BRIDGE_SCRIPT}\n{match.group(0)}",
+            lambda match: f"{bridge_script}\n{match.group(0)}",
             html_content,
             count=1,
             flags=re.IGNORECASE,
         )
 
-    return f"{html_content}\n{_PROJECTOR_CHILD_WHEEL_BRIDGE_SCRIPT}"
+    return f"{html_content}\n{bridge_script}"
 
 
 def _generate_individual_slide_html_sync(slide, slide_number: int, total_slides: int, topic: str) -> str:
@@ -830,16 +942,24 @@ def _generate_individual_slide_html_sync(slide, slide_number: int, total_slides:
     <script>
 {_PROJECTOR_SCALE_JS}
 {_UI_AUTO_HIDE_JS}
-        document.addEventListener('keydown', function (e) {{
-            if (e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'PageUp') {{
+        function handleProjectorKey(key) {{
+            if (key === 'ArrowLeft' || key === 'ArrowUp' || key === 'PageUp') {{
                 if ({slide_number} > 1) window.location.href = 'slide_{slide_number-1}.html';
-            }} else if (e.key === 'ArrowRight' || e.key === 'ArrowDown' || e.key === 'PageDown' || e.key === ' ' || e.key === 'Enter') {{
+                return true;
+            }} else if (key === 'ArrowRight' || key === 'ArrowDown' || key === 'PageDown' || key === ' ' || key === 'Spacebar' || key === 'Enter') {{
                 if ({slide_number} < {total_slides}) window.location.href = 'slide_{slide_number+1}.html';
-            }} else if (e.key === 'Escape') {{
+                return true;
+            }} else if (key === 'Escape') {{
                 window.location.href = 'index.html';
-            }} else if (e.key === 'f' || e.key === 'F') {{
+                return true;
+            }} else if (key === 'f' || key === 'F') {{
                 toggleFullscreen();
+                return true;
             }}
+            return false;
+        }}
+        document.addEventListener('keydown', function (e) {{
+            if (handleProjectorKey(e.key)) e.preventDefault();
         }});
         document.getElementById('stageShield').addEventListener('click', function () {{
             if ({slide_number} < {total_slides}) window.location.href = 'slide_{slide_number+1}.html';
@@ -998,50 +1118,51 @@ def _generate_slideshow_index_sync(project, slide_files: list) -> str:
             grid.appendChild(item);
         }});
 
-        document.addEventListener('keydown', function (e) {{
-            if (overview.classList.contains('visible') && e.key === 'Escape') {{
+        function handleProjectorKey(key) {{
+            if (overview.classList.contains('visible') && key === 'Escape') {{
                 overview.classList.remove('visible');
-                return;
+                return true;
             }}
-            switch (e.key) {{
+            switch (key) {{
                 case 'ArrowLeft':
                 case 'ArrowUp':
                 case 'PageUp':
-                    e.preventDefault();
                     prevSlide();
-                    break;
+                    return true;
                 case 'ArrowRight':
                 case 'ArrowDown':
                 case 'PageDown':
                 case ' ':
+                case 'Spacebar':
                 case 'Enter':
-                    e.preventDefault();
                     nextSlide();
-                    break;
+                    return true;
                 case 'Home':
-                    e.preventDefault();
                     showSlide(0);
-                    break;
+                    return true;
                 case 'End':
-                    e.preventDefault();
                     showSlide(TOTAL - 1);
-                    break;
+                    return true;
                 case 'f':
                 case 'F':
-                    e.preventDefault();
                     toggleFullscreen();
-                    break;
+                    return true;
                 case 'g':
                 case 'G':
-                    e.preventDefault();
                     toggleOverview();
-                    break;
+                    return true;
                 default:
-                    if (e.key >= '1' && e.key <= '9') {{
-                        var n = parseInt(e.key, 10) - 1;
+                    if (key >= '1' && key <= '9') {{
+                        var n = parseInt(key, 10) - 1;
                         if (n < TOTAL) showSlide(n);
+                        return true;
                     }}
             }}
+            return false;
+        }}
+
+        document.addEventListener('keydown', function (e) {{
+            if (handleProjectorKey(e.key)) e.preventDefault();
         }});
     </script>
 </body>

--- a/tests/test_export_support_models.py
+++ b/tests/test_export_support_models.py
@@ -133,6 +133,12 @@ def test_html_zip_export_keeps_interactive_slide_html_without_duplicate_viewers(
         assert "slideFrame.addEventListener('load', installSlideFrameWheelBridge)" in index_html
         assert "window.addEventListener('message'" in index_html
         assert "landppt-projector-wheel" in index_html
+        assert "landppt-projector-key" in index_html
+        assert "function shouldRevealUiForKey(e)" in index_html
+        assert "ArrowLeft: true" in index_html
+        assert "if (navigationKeys[key]) return false;" in index_html
+        assert "if (shouldRevealUiForKey(e)) revealUi();" in index_html
+        assert "function handleProjectorKey(key)" in index_html
         assert "input, textarea, select" in index_html
 
         first_slide = archive.read("slides/slide_1.html").decode("utf-8")
@@ -140,7 +146,31 @@ def test_html_zip_export_keeps_interactive_slide_html_without_duplicate_viewers(
         assert 'onclick="window.clicked = true"' in first_slide
         assert "<script>window.loaded = true;</script>" in first_slide
         assert "window.parent.postMessage({ type: 'landppt-projector-wheel'" in first_slide
+        assert "window.parent.postMessage({ type: 'landppt-projector-key'" in first_slide
+        assert "window.addEventListener('keydown'" in first_slide
+        assert "if (e.defaultPrevented) return;" in first_slide
+        assert "'button'" in first_slide
+        assert "'a[href]'" in first_slide
+        assert "'[tabindex]:not([tabindex=\"-1\"])" in first_slide
 
         second_slide = archive.read("slides/slide_2.html").decode("utf-8")
         assert 'onclick="window.second = true"' in second_slide
         assert "window.parent.postMessage({ type: 'landppt-projector-wheel'" in second_slide
+        assert "window.parent.postMessage({ type: 'landppt-projector-key'" in second_slide
+
+
+def test_html_slide_bridge_adds_keyboard_bridge_when_wheel_marker_already_exists():
+    module = _load_export_support_module()
+    html = """
+<html>
+<body>
+    <script>window.marker = 'landppt-projector-wheel';</script>
+</body>
+</html>
+"""
+
+    enhanced = module._inject_projector_child_wheel_bridge(html)
+
+    assert "landppt-projector-wheel" in enhanced
+    assert "landppt-projector-key" in enhanced
+    assert enhanced.count("landppt-projector-wheel") == 1


### PR DESCRIPTION
## Summary
- Prevent exported projector controls from reappearing when navigation keys are pressed.
- Forward projector keyboard shortcuts from exported slide iframes back to the parent viewer after wheel navigation.
- Preserve slide-level interactive keyboard behavior by skipping focusable targets and already-handled events.

## Verification
- uv run --extra dev pytest tests/test_export_support_models.py tests/test_slideshow_interactivity.py -q
- uv run --extra dev pytest tests/test_web_route_modularization.py::test_extracted_route_modules_keep_expected_public_paths tests/test_web_route_modularization.py::test_project_slides_editor_template_uses_extracted_assets -q
- git diff --check (CRLF warnings only)