### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ OpenAI GPT（及兼容接口）、Anthropic Claude、Google Gemini、Azure OpenA
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sligter/LandPPT&type=Date)](https://www.star-history.com/#sligter/LandPPT&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sligter/LandPPT&type=Date)](https://star-history.dera.page/#sligter/LandPPT&Date)
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -472,7 +472,7 @@ Licensed under the [Apache License 2.0](LICENSE).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sligter/LandPPT&type=Date)](https://www.star-history.com/#sligter/LandPPT&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sligter/LandPPT&type=Date)](https://star-history.dera.page/#sligter/LandPPT&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders. This fixes the chart by pointing it to a working alternative, so it displays correctly again.