### PR TITLE
fix: preserve Pollinations image quality with canonical model IDs

### DIFF
--- a/src/landppt/services/image/providers/pollinations_provider.py
+++ b/src/landppt/services/image/providers/pollinations_provider.py
@@ -192,7 +192,10 @@ class PollinationsProvider(ImageGenerationProvider):
         if self.default_safe:
             params.append("safe=true")
 
-        if model in {"gptimage", "gptimage-large"} and request.quality:
+        if model in {
+            "gptimage", "gptimage-large",
+            "openai/gpt-image-1-mini", "openai/gpt-image-1.5",
+        } and request.quality:
             q = request.quality.strip().lower()
             params.append("quality=hd" if q == "hd" else "quality=medium")
 

--- a/tests/test_pollinations_provider.py
+++ b/tests/test_pollinations_provider.py
@@ -1,0 +1,28 @@
+import unittest
+from urllib.parse import parse_qs, urlsplit
+
+from landppt.services.image.models import ImageGenerationRequest, ImageProvider
+from landppt.services.image.providers.pollinations_provider import PollinationsProvider
+
+
+class PollinationsQualityTest(unittest.IsolatedAsyncioTestCase):
+    async def test_gpt_image_quality_with_catalog_names_and_aliases(self):
+        provider = PollinationsProvider({"api_key": "test-key"})
+        for model in ("gptimage", "gptimage-large", "openai/gpt-image-1-mini", "openai/gpt-image-1.5"):
+            for quality, expected in (("hd", "hd"), ("standard", "medium")):
+                with self.subTest(model=model, quality=quality):
+                    request = ImageGenerationRequest(
+                        prompt="presentation background", provider=ImageProvider.POLLINATIONS,
+                        model=model, quality=quality,
+                    )
+                    query = parse_qs(urlsplit(provider._build_api_url(request)).query)
+                    self.assertEqual(query["model"], [model])
+                    self.assertEqual(query.get("quality"), [expected])
+
+    async def test_other_models_do_not_receive_gpt_quality(self):
+        provider = PollinationsProvider({"api_key": "test-key"})
+        request = ImageGenerationRequest(
+            prompt="presentation background", provider=ImageProvider.POLLINATIONS,
+            model="black-forest-labs/flux-1-schnell", quality="hd",
+        )
+        self.assertNotIn("quality", parse_qs(urlsplit(provider._build_api_url(request)).query))


### PR DESCRIPTION
- Keeps GPT image quality settings working when the model picker returns canonical IDs from Pollinations.
- Preserves existing aliases and leaves other models unchanged. Background: https://github.com/pollinations/pollinations/pull/13076
- Adds real URL-builder tests covering canonical IDs, aliases, HD/standard quality, and unrelated models.
- Tested: `PYTHONPATH=src python -m unittest discover -s tests -p test_pollinations_provider.py` (2 tests; canonical cases failed before the fix). No image generation required.